### PR TITLE
feat: rewrite library in TypeScript for v1.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
           run_install: false
 
       - uses: actions/setup-node@v4
@@ -30,8 +29,39 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: EsLint
+      - name: ESLint
         run: pnpm lint
 
       - name: Stylelint
         run: pnpm stylelint
+
+  verify:
+    name: Typecheck, test & build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test (with coverage)
+        run: pnpm test:coverage
+
+      - name: Build
+        run: pnpm build

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -25,7 +25,6 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
           run_install: false
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -8,6 +8,7 @@ on:
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'vite.config.js'
+      - 'tsconfig.json'
       - 'README.md'
   workflow_dispatch:
 
@@ -22,34 +23,34 @@ jobs:
       version_changed: ${{ steps.check.outputs.version_changed }}
     steps:
       - uses: actions/checkout@v4
-
-      - name: Get previous version
-        id: previous
-        run: echo "PREV_VERSION=$(git show HEAD^:package.json | jq -r .version)" >> $GITHUB_ENV
-
-      - name: Get current version
-        id: current
-        run: echo "CURR_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
+        with:
+          fetch-depth: 2
 
       - name: Check if version changed
         id: check
         run: |
+          PREV_VERSION=$(git show HEAD^:package.json | jq -r .version)
+          CURR_VERSION=$(jq -r .version package.json)
+          echo "previous=$PREV_VERSION current=$CURR_VERSION"
           if [ "$PREV_VERSION" != "$CURR_VERSION" ]; then
-            echo "version_changed=true" >> $GITHUB_ENV
+            echo "version_changed=true" >> "$GITHUB_OUTPUT"
           else
-            echo "version_changed=false" >> $GITHUB_ENV
+            echo "version_changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-  build:
+  publish:
     needs: check-version
+    if: needs.check-version.outputs.version_changed == 'true'
     name: Publish to NPM
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # npm provenance
     steps:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
           run_install: false
 
       - uses: actions/setup-node@v4
@@ -61,10 +62,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
       - name: Build
         run: pnpm build-lib
 
       - name: Publish
-        run: pnpm publish --access public --no-git-checks
+        run: pnpm publish --access public --no-git-checks --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+coverage
 *.local
 
 # Editor directories and files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/), and this project adheres to
+[Semantic Versioning](https://semver.org/).
+
+## [1.0.0]
+
+A quality-focused release: the library is now written in TypeScript and ships
+its own types, has a full test suite, and fixes several runtime bugs. Most apps
+need **no code changes** — the default plugin import and all props/events/methods
+are unchanged.
+
+### Added
+
+- **TypeScript types are now shipped** (`dist/lib/index.d.ts`). Props, events,
+  and the player instance are fully typed. A `VueYtframeInstance` type is
+  exported for typing template refs: `ref<VueYtframeInstance>()`.
+- **Named component export** for local registration:
+  `import { VueYtframe } from "vue3-ytframe"`. The default plugin export
+  (`app.use(VueYtframe)`) still works.
+- `getVideoIdFromYoutubeURL` is now also exported as a standalone helper.
+- Extended URL parsing: `shorts/`, `live/`, `youtube-nocookie.com`, `/v/`,
+  `http`, and `watch` URLs where `v=` is not the first query parameter.
+- Unit tests (Vitest) covering URL parsing, debounce behavior, component
+  lifecycle, the full method surface, and a docs/API drift guard.
+
+### Fixed
+
+- **Debounce now actually coalesces.** Previously a new debounced function was
+  created on every prop change, so rapid `videoId`/`videoUrl` updates were never
+  debounced. Timing is now correct (300ms for `videoId`, 500ms for `videoUrl`).
+- **The player is destroyed on unmount.** Previously the `YT.Player` and its
+  iframe leaked when the component unmounted; cleanup now runs automatically.
+- **Bounded API loading.** The recursive `window.YT` poll now times out instead
+  of spinning forever when the YouTube script is blocked or offline.
+- Consistent autoplay detection between the `videoId` and `videoUrl` code paths.
+- `endSeconds` is no longer forced to `0` when unset (which told YouTube to end
+  at 0s); it is now omitted.
+- Calling a player method before the player is ready throws a clear, descriptive
+  error instead of a raw `Cannot read properties of null`.
+
+### Changed
+
+- Source converted from JavaScript to TypeScript (`<script setup lang="ts">`).
+- The library no longer logs to the console in production (diagnostics are
+  dev-only).
+- UMD build now uses named exports; CDN consumers access the plugin via
+  `VueYtframe.default` and the component via `VueYtframe.VueYtframe`.
+- `@types/youtube` is a runtime dependency so consumer types resolve out of the box.
+
+### Migration
+
+- **ESM / bundler users:** no changes required. `import VueYtframe from "vue3-ytframe"`
+  + `app.use(VueYtframe)` continues to work, and you can now also
+  `import { VueYtframe } from "vue3-ytframe"` for local registration.
+- **UMD / CDN users:** the global is now a namespace — use `VueYtframe.default`
+  for the plugin (or `VueYtframe.VueYtframe` for the component) instead of the
+  bare global.
+- If you relied on the previous (non-functional) debounce timing or on the player
+  surviving unmount, review those flows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ are unchanged.
   debounced. Timing is now correct (300ms for `videoId`, 500ms for `videoUrl`).
 - **The player is destroyed on unmount.** Previously the `YT.Player` and its
   iframe leaked when the component unmounted; cleanup now runs automatically.
+- **Changing `videoUrl` now reloads the player.** The reactive handler used
+  `cueVideoByUrl`/`loadVideoByUrl`, which the YouTube API only accepts in the
+  `.../v/ID?version=3` format — so a normal watch/short URL silently did nothing.
+  It now resolves the video ID and reloads via `cueVideoById`/`loadVideoById`.
 - **Bounded API loading.** The recursive `window.YT` poll now times out instead
   of spinning forever when the YouTube script is blocked or offline.
 - Consistent autoplay detection between the `videoId` and `videoUrl` code paths.

--- a/README.md
+++ b/README.md
@@ -2,16 +2,128 @@
 	<img src="./src/assets/youtube.svg" width="80">
 </p>
 <h1 align=center>Vue3 Ytframe</h1>
-<p align=center>A YouTube Iframe API Wrapper</p>
+<p align=center>A fully-typed Vue 3 wrapper around the YouTube Iframe API.</p>
 <p align="center">
-<a href="https://www.npmjs.com/package/vue3-ytframe"><img src="https://img.shields.io/npm/v/vue3-ytframe.svg"/> <img src="https://img.shields.io/npm/dm/vue3-ytframe.svg"/></a> <a href="https://vuejs.org/"><img src="https://img.shields.io/badge/vue-3-brightgreen.svg"/></a>
+<a href="https://www.npmjs.com/package/vue3-ytframe"><img src="https://img.shields.io/npm/v/vue3-ytframe.svg" alt="npm version"/> <img src="https://img.shields.io/npm/dm/vue3-ytframe.svg" alt="npm downloads"/></a>
+<a href="https://vuejs.org/"><img src="https://img.shields.io/badge/vue-3-brightgreen.svg" alt="Vue 3"/></a>
+<img src="https://img.shields.io/badge/types-included-blue.svg" alt="TypeScript types included"/>
 </p>
 
-## Documentation
-https://kiranparajuli589.github.io/vue3-ytframe/#/docs/ref=
+## Features
 
-## Playground
-https://kiranparajuli589.github.io/vue3-ytframe/#/playground
+- 🧩 Single component that wraps the **entire** YouTube Iframe API (all methods & events)
+- 🟦 **Ships TypeScript types** — typed props, events, and the player instance
+- 🪶 Zero runtime dependencies beyond Vue 3 itself
+- ⏳ Promise-based API loading, so the player is created only once YouTube is ready
+- ♻️ Automatically destroys the player on unmount (no leaks)
+- 📦 Ships ESM **and** CommonJS builds (Node SSR / `require()` friendly)
 
-## Usage Examples
-https://kiranparajuli589.github.io/vue3-ytframe/#/docs/ref=examples
+## Installation
+
+```bash
+npm install vue3-ytframe
+# or: pnpm add vue3-ytframe / yarn add vue3-ytframe
+```
+
+Requires `vue` `^3.5` as a peer dependency.
+
+## Usage
+
+### Option A — register globally (plugin)
+
+```ts
+import { createApp } from "vue"
+import VueYtframe from "vue3-ytframe"
+import App from "./App.vue"
+
+createApp(App).use(VueYtframe).mount("#app")
+```
+
+### Option B — register locally (named export)
+
+```vue
+<script setup lang="ts">
+import { VueYtframe } from "vue3-ytframe"
+</script>
+
+<template>
+	<VueYtframe video-id="kGb9ftWR3l8" :player-vars="{ autoplay: 0 }" />
+</template>
+```
+
+### Controlling the player with a template ref
+
+```vue
+<script setup lang="ts">
+import { ref } from "vue"
+import { VueYtframe, type VueYtframeInstance } from "vue3-ytframe"
+
+const yt = ref<VueYtframeInstance>()
+
+function onReady() {
+	yt.value?.playVideo()
+}
+</script>
+
+<template>
+	<VueYtframe ref="yt" video-id="kGb9ftWR3l8" @ready="onReady" />
+</template>
+```
+
+## Props
+
+| Prop         | Type              | Default   | Description                                              |
+|--------------|-------------------|-----------|----------------------------------------------------------|
+| `videoId`    | `string`          | `null`    | YouTube video ID. One of `videoId`/`videoUrl` required.  |
+| `videoUrl`   | `string`          | `null`    | Full YouTube URL (parsed to an ID internally).           |
+| `width`      | `number \| string`| `"100%"`  | Player width.                                            |
+| `height`     | `number \| string`| `"100%"`  | Player height.                                           |
+| `playerVars` | `object`          | `{}`      | [YouTube player parameters](https://developers.google.com/youtube/player_parameters). |
+
+## Events
+
+`ready`, `playing`, `paused`, `ended`, `stateChange`, `playbackQualityChange`,
+`playbackRateChange`, `error`, `apiChange` — each emits the underlying
+`YT.Player`. See the [Events docs](https://kiranparajuli589.github.io/vue3-ytframe/#/docs/ref=events).
+
+## Methods
+
+The full Iframe API surface is exposed on the component instance
+(`playVideo`, `pauseVideo`, `seekTo`, `mute`, `setVolume`, `loadVideoById`, …).
+The pure helper `getVideoIdFromYoutubeURL(url)` is also exported standalone.
+See the [Methods docs](https://kiranparajuli589.github.io/vue3-ytframe/#/docs/ref=methods).
+
+> Player methods throw a clear error if called before the `ready` event — wait
+> for `ready` (or check the exposed `player` ref) before driving playback.
+
+## SSR (Nuxt, Quasar, etc.)
+
+`vue3-ytframe` ships a `.cjs` build, so Node SSR servers can `require()` it
+without `ERR_REQUIRE_ESM`. The player itself uses the browser YouTube Iframe API
+(`document`, `window`), so render it **client-only** (e.g. Quasar's `QNoSsr`,
+Nuxt's `<ClientOnly>`).
+
+## Links
+
+- 📖 [Documentation](https://kiranparajuli589.github.io/vue3-ytframe/#/docs/ref=)
+- 🎛️ [Playground](https://kiranparajuli589.github.io/vue3-ytframe/#/playground)
+- 🧪 [Usage examples](https://kiranparajuli589.github.io/vue3-ytframe/#/docs/ref=examples)
+- 📝 [Changelog](./CHANGELOG.md)
+
+## Contributing
+
+```bash
+pnpm install      # install deps
+pnpm dev          # run the docs/playground site
+pnpm test         # run the unit tests
+pnpm typecheck    # vue-tsc type checking
+pnpm lint         # eslint
+pnpm build        # build the library + docs
+```
+
+Issues and PRs are welcome at the
+[GitHub repository](https://github.com/kiranparajuli589/vue3-ytframe).
+
+## License
+
+[GPL-3.0](./LICENSE) © Kiran Parajuli

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,17 +1,29 @@
 import js from "@eslint/js"
 import pluginVue from "eslint-plugin-vue"
+import tseslint from "typescript-eslint"
+import vueParser from "vue-eslint-parser"
 import globals from "globals"
 
 export default [
+	{
+		ignores: ["dist/**", "docs/**", "node_modules/**"],
+	},
 	js.configs.recommended,
+	...tseslint.configs.recommended,
 	...pluginVue.configs["flat/essential"],
 	{
-		files: ["**/*.{js,vue}"],
+		files: ["**/*.{js,ts,vue}"],
 		languageOptions: {
 			ecmaVersion: "latest",
 			sourceType: "module",
+			parser: vueParser,
+			parserOptions: {
+				parser: tseslint.parser,
+			},
 			globals: {
 				...globals.browser,
+				...globals.node,
+				YT: "readonly",
 			},
 		},
 		rules: {
@@ -19,6 +31,7 @@ export default [
 			"linebreak-style": "off",
 			quotes: ["error", "double"],
 			semi: ["error", "never"],
+			"@typescript-eslint/no-unused-vars": ["error", {argsIgnorePattern: "^_"}],
 		},
 	},
 ]

--- a/lib/VueYtframe.vue
+++ b/lib/VueYtframe.vue
@@ -1,201 +1,185 @@
 <template>
-	<div ref="youtube" :id="playerId"></div>
+	<div :id="playerId" ref="youtube"></div>
 </template>
-<script setup>
-import {onMounted, ref, watch} from "vue"
+<script setup lang="ts">
+import {onBeforeUnmount, onMounted, ref, watch} from "vue"
+import {debounce, getVideoIdFromYoutubeURL, warn} from "./utils"
+import type {VueYtframeProps, LoadVideoByIdOptions, LoadVideoByUrlOptions} from "./types"
+import {YT_API_SRC, YT_LOAD_TIMEOUT, YT_POLL_INTERVAL} from "./constants"
 
-const player = ref(null)
+const props = withDefaults(defineProps<VueYtframeProps>(), {
+	videoId: null,
+	videoUrl: null,
+	width: "100%",
+	height: "100%",
+	playerVars: () => ({}),
+})
+
+const emit = defineEmits<{
+	ready: [player: YT.Player]
+	playing: [player: YT.Player]
+	paused: [player: YT.Player]
+	ended: [player: YT.Player]
+	stateChange: [player: YT.Player]
+	playbackQualityChange: [player: YT.Player]
+	playbackRateChange: [player: YT.Player]
+	error: [player: YT.Player]
+	apiChange: [player: YT.Player]
+}>()
+
+const player = ref<YT.Player | null>(null)
+const playerId = ref("")
 const urlValidity = ref(false)
 
-const props = defineProps({
-	videoId: {
-		type: String,
-		required: false,
-		default: null
-	},
-	videoUrl: {
-		type: String,
-		required: false,
-		default: null
-	},
-	width: {
-		type: [Number, String],
-		required: false,
-		default: "100%",
-	},
-	height: {
-		type: [Number, String],
-		required: false,
-		default: "100%",
-	},
-	playerVars: {
-		type: Object,
-		required: false,
-		default: () => ({}),
-	},
-})
+let pollTimer: ReturnType<typeof setTimeout> | undefined
+
+const debouncedIdChange = debounce(onVideoIdChange, 300)
+const debouncedUrlChange = debounce(onVideoUrlChange, 500)
 
 watch(
 	[() => props.width, () => props.height],
 	([width, height]) => {
 		if (player.value) {
-			setSize(width, height)
+			player.value.setSize(Number(width), Number(height))
 		}
-	}
+	},
 )
 
-watch(() => props.videoId, (videoId) => {
-	debounce(() => {
-		onVideoIdChange(videoId)
-	}, 300)()
-})
+watch(() => props.videoId, (videoId) => debouncedIdChange(videoId))
+watch(() => props.videoUrl, (videoUrl) => debouncedUrlChange(videoUrl))
 
-function onVideoIdChange(videoId) {
+function onVideoIdChange(videoId: string | null): void {
 	validate()
-	if (urlValidity.value) {
-		if (player.value) {
-			if (props.playerVars?.autoplay === 1) {
-				loadVideoById({
-					videoId,
-					startSeconds: props.playerVars.start || 0,
-					endSeconds: props.playerVars.end || 0,
-				})
-			} else {
-				cueVideoById({
-					videoId,
-					startSeconds: props.playerVars.start || 0,
-					endSeconds: props.playerVars.end || 0,
-				})
-			}
-		} else {
-			createPlayer()
-		}
-	}
-}
-
-watch(() => props.videoUrl, (videoUrl) => {
-	debounce(() => {
-		onVideoUrlChange(videoUrl)
-	}, 500)()
-})
-
-function onVideoUrlChange(videoUrl) {
-	validate()
-	if (urlValidity.value) {
-		if (player.value) {
-			if (props.playerVars?.autoplay) {
-				loadVideoByUrl({
-					mediaContentUrl: videoUrl,
-					startSeconds: props.playerVars.start || 0,
-					endSeconds: props.playerVars.end || 0,
-				})
-			} else {
-				cueVideoByUrl({
-					mediaContentUrl: videoUrl,
-					startSeconds: props.playerVars.start || 0,
-					endSeconds: props.playerVars.end || 0,
-				})
-			}
-		} else {
-			createPlayer()
-		}
-	}
-}
-
-function validate() {
-	const videoId = props.videoId
-	const videoUrl = props.videoUrl
-	if (!videoId && !videoUrl) {
-		urlValidity.value = false
-		console.error("At least one of the props 'videoId' or 'videoUrl' must be provided.")
+	if (!urlValidity.value || !videoId) return
+	if (!player.value) {
+		createPlayer()
 		return
 	}
-	if (!videoId && videoUrl) {
-		if (!getVideoIdFromYoutubeURL(videoUrl)) {
-			console.error(`The provided video URL (${videoUrl}) is not a valid Youtube URL.`,
-				"If you are sure it is a valid YouTube URL and you are still getting this error,",
-				"please open an issue on GitHub at https://github.com/kiranparajuli589/vue3-ytframe/issues/new"
-			)
-			urlValidity.value = false
-			return
-		}
+	const args = {
+		videoId,
+		startSeconds: props.playerVars?.start || 0,
+		endSeconds: props.playerVars?.end || undefined,
+	}
+	if (props.playerVars?.autoplay === 1) {
+		player.value.loadVideoById(args)
+	} else {
+		player.value.cueVideoById(args)
+	}
+}
+
+function onVideoUrlChange(videoUrl: string | null): void {
+	validate()
+	if (!urlValidity.value || !videoUrl) return
+	if (!player.value) {
+		createPlayer()
+		return
+	}
+	const args = {
+		mediaContentUrl: videoUrl,
+		startSeconds: props.playerVars?.start || 0,
+		endSeconds: props.playerVars?.end || undefined,
+	}
+	if (props.playerVars?.autoplay === 1) {
+		player.value.loadVideoByUrl(args)
+	} else {
+		player.value.cueVideoByUrl(args)
+	}
+}
+
+function validate(): void {
+	const {videoId, videoUrl} = props
+	if (!videoId && !videoUrl) {
+		urlValidity.value = false
+		warn("At least one of the props 'videoId' or 'videoUrl' must be provided.")
+		return
+	}
+	if (!videoId && videoUrl && !getVideoIdFromYoutubeURL(videoUrl)) {
+		urlValidity.value = false
+		warn(`The provided video URL (${videoUrl}) is not a valid YouTube URL.`)
+		return
 	}
 	urlValidity.value = true
 }
 
-const playerId = ref(null)
+let idCounter = 0
 
-onMounted(async () => {
-	// assign a random id to the player
-	playerId.value = Math.random().toString(36).substring(2, 12)
+function generatePlayerId(): string {
+	if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+		return `ytframe-${crypto.randomUUID()}`
+	}
+	return `ytframe-${(++idCounter).toString(36)}`
+}
 
-	validate(props.videoId, props.videoUrl)
-
-	loadAPI().then(() => {
-		checkIfYTLoaded().then(() => {
-			if (urlValidity.value) {
-				createPlayer()
-			}
+onMounted(() => {
+	playerId.value = generatePlayerId()
+	validate()
+	loadAPI()
+	whenYTReady()
+		.then(() => {
+			if (urlValidity.value) createPlayer()
 		})
-	})
+		.catch((err: Error) => warn(err.message))
 })
 
-function loadAPI() {
-	if (document.querySelector("script[src='https://www.youtube.com/iframe_api']")) {
-		return Promise.resolve()
+onBeforeUnmount(() => {
+	debouncedIdChange.cancel()
+	debouncedUrlChange.cancel()
+	if (pollTimer) clearTimeout(pollTimer)
+	if (player.value) {
+		player.value.destroy()
+		player.value = null
 	}
+})
+
+/** Injects the YouTube Iframe API script once per document. */
+function loadAPI(): void {
+	if (window.YT && window.YT.Player) return
+	if (document.querySelector(`script[src="${YT_API_SRC}"]`)) return
 	const tag = document.createElement("script")
-	tag.src = "https://www.youtube.com/iframe_api"
+	tag.src = YT_API_SRC
 	document.head.appendChild(tag)
-	console.info("Youtube API script added to the HTML document.")
-	return Promise.resolve()
 }
 
-function checkIfYTLoaded() {
-	if (window.YT && window.YT.Player) {
-		return Promise.resolve()
-	}
-	// recursively check if the YT object is loaded
-	 
-	return new Promise((resolve) => {
-		setTimeout(() => {
-			checkIfYTLoaded().then(() => {
+/** Resolves when `window.YT.Player` is available, rejecting after a timeout. */
+function whenYTReady(): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const start = Date.now()
+		const check = (): void => {
+			if (window.YT && window.YT.Player) {
 				resolve()
-			})
-		}, 100)
+				return
+			}
+			if (Date.now() - start > YT_LOAD_TIMEOUT) {
+				reject(new Error("YouTube Iframe API failed to load within timeout."))
+				return
+			}
+			pollTimer = setTimeout(check, YT_POLL_INTERVAL)
+		}
+		check()
 	})
 }
 
-const emit = defineEmits([
-	"ready", "playing", "paused", "ended", "stateChange",
-	"playbackQualityChange", "playbackRateChange", "error", "apiChange"
-])
-
-function createPlayer() {
-	const playerElement = document.getElementById(playerId.value)
-	const videoID = props.videoId || getVideoIdFromYoutubeURL(props.videoUrl)
-	// eslint-disable-next-line no-undef
-	player.value = new YT.Player(playerElement, {
+function createPlayer(): void {
+	const el = document.getElementById(playerId.value)
+	if (!el) return
+	const videoId = props.videoId || getVideoIdFromYoutubeURL(props.videoUrl) || undefined
+	player.value = new window.YT.Player(el, {
 		height: props.height,
 		width: props.width,
-		videoId: videoID,
+		videoId,
 		playerVars: props.playerVars,
 		events: {
-			"onReady": onPlayerReady,
-			"onStateChange": onPlayerStateChange,
-			"onPlaybackQualityChange": onPlaybackQualityChange,
-			"onPlaybackRateChange": onPlaybackRateChange,
-			"onError": onError,
-			"onApiChange": onApiChange,
-		}
+			onReady: (event) => emit("ready", event.target),
+			onStateChange: onPlayerStateChange,
+			onPlaybackQualityChange: (event) => emit("playbackQualityChange", event.target),
+			onPlaybackRateChange: (event) => emit("playbackRateChange", event.target),
+			onError: (event) => emit("error", event.target),
+			onApiChange: (event) => emit("apiChange", event.target),
+		},
 	})
 }
 
-function onPlayerReady(event) {
-	emit("ready", event.target)
-}
-
-function onPlayerStateChange(event) {
+function onPlayerStateChange(event: YT.OnStateChangeEvent): void {
 	switch (event.data) {
 	case window.YT.PlayerState.PLAYING:
 		emit("playing", event.target)
@@ -210,418 +194,212 @@ function onPlayerStateChange(event) {
 	emit("stateChange", event.target)
 }
 
-function onPlaybackQualityChange(event) {
-	emit("playbackQualityChange", event.target)
+/** Throws a clear error when a player method is called before the player is ready. */
+function ensurePlayer(): YT.Player {
+	if (!player.value) {
+		throw new Error(
+			"[vue3-ytframe] Player is not ready. Wait for the 'ready' event before calling player methods.",
+		)
+	}
+	return player.value
 }
 
-function onPlaybackRateChange(event) {
-	emit("playbackRateChange", event.target)
+/** @see https://developers.google.com/youtube/iframe_api_reference#playVideo */
+function playVideo(): void {
+	ensurePlayer().playVideo()
 }
 
-function onError(event) {
-	emit("error", event.target)
+/** @see https://developers.google.com/youtube/iframe_api_reference#pauseVideo */
+function pauseVideo(): void {
+	ensurePlayer().pauseVideo()
 }
 
-function onApiChange(event) {
-	emit("apiChange", event.target)
+/** @see https://developers.google.com/youtube/iframe_api_reference#stopVideo */
+function stopVideo(): void {
+	ensurePlayer().stopVideo()
 }
 
-/**
- * @see https://developers.google.com/youtube/iframe_api_reference#playVideo
- */
-function playVideo() {
-	player.value.playVideo()
+/** @see https://developers.google.com/youtube/iframe_api_reference#seekTo */
+function seekTo(seconds: number, allowSeekAhead: boolean): void {
+	ensurePlayer().seekTo(seconds, allowSeekAhead)
 }
 
-/**
- * @see https://developers.google.com/youtube/iframe_api_reference#pauseVideo
- */
-function pauseVideo() {
-	player.value.pauseVideo()
+/** @see https://developers.google.com/youtube/iframe_api_reference#nextVideo */
+function nextVideo(): void {
+	ensurePlayer().nextVideo()
 }
 
-/**
- * @see https://developers.google.com/youtube/iframe_api_reference#stopVideo
- */
-function stopVideo() {
-	player.value.stopVideo()
+/** @see https://developers.google.com/youtube/iframe_api_reference#previousVideo */
+function previousVideo(): void {
+	ensurePlayer().previousVideo()
 }
 
-/**
- * @param {Number} seconds
- * @param {Boolean} allowSeekAhead
- *
- * @see https://developers.google.com/youtube/iframe_api_reference#seekTo
- */
-function seekTo(seconds, allowSeekAhead) {
-	player.value.seekTo(seconds, allowSeekAhead)
+/** @see https://developers.google.com/youtube/iframe_api_reference#playVideoAt */
+function playVideoAt(index: number): void {
+	ensurePlayer().playVideoAt(index)
 }
 
-/**
- * @see https://developers.google.com/youtube/iframe_api_reference#nextVideo
- */
-function nextVideo() {
-	player.value.nextVideo()
+/** @see https://developers.google.com/youtube/iframe_api_reference#mute */
+function mute(): void {
+	ensurePlayer().mute()
 }
 
-/**
- * @see https://developers.google.com/youtube/iframe_api_reference#previousVideo
- */
-function previousVideo() {
-	player.value.previousVideo()
+/** @see https://developers.google.com/youtube/iframe_api_reference#unMute */
+function unMute(): void {
+	ensurePlayer().unMute()
 }
 
-/**
- * @param {Number} index
- * @see https://developers.google.com/youtube/iframe_api_reference#playVideoAt
- */
-function playVideoAt(index) {
-	player.value.playVideoAt(index)
+/** @see https://developers.google.com/youtube/iframe_api_reference#isMuted */
+function isMuted(): boolean {
+	return ensurePlayer().isMuted()
 }
 
-/**
- * @see https://developers.google.com/youtube/iframe_api_reference#mute
- */
-function mute() {
-	player.value.mute()
+/** @see https://developers.google.com/youtube/iframe_api_reference#setVolume */
+function setVolume(volume: number): void {
+	ensurePlayer().setVolume(volume)
 }
 
-/**
- * @see https://developers.google.com/youtube/iframe_api_reference#unMute
- */
-function unMute() {
-	player.value.unMute()
+/** @see https://developers.google.com/youtube/iframe_api_reference#getVolume */
+function getVolume(): number {
+	return ensurePlayer().getVolume()
 }
 
-/**
- * @returns {Boolean}
- * @see https://developers.google.com/youtube/iframe_api_reference#isMuted
- */
-function isMuted() {
-	return player.value.isMuted()
+/** @see https://developers.google.com/youtube/iframe_api_reference#setSize */
+function setSize(width: number, height: number): void {
+	ensurePlayer().setSize(width, height)
 }
 
-/**
- * @param {Number} volume
- *
- * @see https://developers.google.com/youtube/iframe_api_reference#setVolume
- */
-function setVolume(volume) {
-	player.value.setVolume(volume)
+/** @see https://developers.google.com/youtube/iframe_api_reference#setLoop */
+function setLoop(loopPlaylists: boolean): void {
+	ensurePlayer().setLoop(loopPlaylists)
 }
 
-/**
- * @see https://developers.google.com/youtube/iframe_api_reference#getVolume
- * @returns {Number}
- */
-function getVolume() {
-	return player.value.getVolume()
+/** @see https://developers.google.com/youtube/iframe_api_reference#setShuffle */
+function setShuffle(shufflePlaylist: boolean): void {
+	ensurePlayer().setShuffle(shufflePlaylist)
 }
 
-/**
- * @param {Number} width
- * @param {Number} height
- *
- * @see https://developers.google.com/youtube/iframe_api_reference#setSize
- */
-function setSize(width, height) {
-	player.value.setSize(width, height)
+/** @see https://developers.google.com/youtube/iframe_api_reference#getDuration */
+function getDuration(): number {
+	return ensurePlayer().getDuration()
 }
 
-/**
- * @param {Boolean} loopPlayLists
- * @see https://developers.google.com/youtube/iframe_api_reference#setLoop
- */
-function setLoop(loopPlayLists) {
-	player.value.setLoop(loopPlayLists)
+/** @see https://developers.google.com/youtube/iframe_api_reference#getCurrentTime */
+function getCurrentTime(): number {
+	return ensurePlayer().getCurrentTime()
 }
 
-/**
- * @param {Boolean} shufflePlaylist
- * @see https://developers.google.com/youtube/iframe_api_reference#setShuffle
- */
-function setShuffle(shufflePlaylist) {
-	player.value.setShuffle(shufflePlaylist)
+/** @see https://developers.google.com/youtube/iframe_api_reference#getVideoEmbedCode */
+function getVideoEmbedCode(): string {
+	return ensurePlayer().getVideoEmbedCode()
 }
 
-/**
- * @returns {Number}
- * @see https://developers.google.com/youtube/iframe_api_reference#getDuration
- */
-function getDuration() {
-	return player.value.getDuration()
+/** @see https://developers.google.com/youtube/iframe_api_reference#getVideoUrl */
+function getVideoUrl(): string {
+	return ensurePlayer().getVideoUrl()
 }
 
-/**
- * @returns {Number}
- * @see https://developers.google.com/youtube/iframe_api_reference#getCurrentTime
- */
-function getCurrentTime() {
-	return player.value.getCurrentTime()
+/** @see https://developers.google.com/youtube/iframe_api_reference#getVideoLoadedFraction */
+function getVideoLoadedFraction(): number {
+	return ensurePlayer().getVideoLoadedFraction()
 }
 
-/**
- * @returns {String}
- * @see https://developers.google.com/youtube/iframe_api_reference#getVideoEmbedCode
- */
-function getVideoEmbedCode() {
-	return player.value.getVideoEmbedCode()
+/** @see https://developers.google.com/youtube/iframe_api_reference#getPlayerState */
+function getPlayerState(): number {
+	return ensurePlayer().getPlayerState()
 }
 
-/**
- * @returns {String}
- * @see https://developers.google.com/youtube/iframe_api_reference#getVideoUrl
- */
-function getVideoUrl() {
-	return player.value.getVideoUrl()
+/** @see https://developers.google.com/youtube/iframe_api_reference#getPlaybackRate */
+function getPlaybackRate(): number {
+	return ensurePlayer().getPlaybackRate()
 }
 
-/**
- * @returns {Number} Floating point number between 0 and 1
- * @see https://developers.google.com/youtube/iframe_api_reference#getVideoLoadedFraction
- */
-function getVideoLoadedFraction() {
-	return player.value.getVideoLoadedFraction()
+/** @see https://developers.google.com/youtube/iframe_api_reference#setPlaybackRate */
+function setPlaybackRate(suggestedRate: number): void {
+	ensurePlayer().setPlaybackRate(suggestedRate)
 }
 
-/**
- * @returns {Number}
- * @see https://developers.google.com/youtube/iframe_api_reference#getPlayerState
- */
-function getPlayerState() {
-	return player.value.getPlayerState()
+/** @see https://developers.google.com/youtube/iframe_api_reference#getAvailablePlaybackRates */
+function getAvailablePlaybackRates(): number[] {
+	return ensurePlayer().getAvailablePlaybackRates()
 }
 
-/**
- * @returns {Number}
- * @see https://developers.google.com/youtube/iframe_api_reference#getPlaybackRate
- */
-function getPlaybackRate() {
-	return player.value.getPlaybackRate()
+/** @see https://developers.google.com/youtube/iframe_api_reference#onApiChange */
+function getOptions(): string[] {
+	return ensurePlayer().getOptions()
 }
 
-/**
- * @param {Number} suggestedRate
- * @see https://developers.google.com/youtube/iframe_api_reference#setPlaybackRate
- */
-function setPlaybackRate(suggestedRate) {
-	player.value.setPlaybackRate(suggestedRate)
+/** @see https://developers.google.com/youtube/iframe_api_reference#onApiChange */
+function getAnOption(module: string, option: string): unknown {
+	return ensurePlayer().getOption(module, option)
 }
 
-/**
- * @returns {Array}
- * @see https://developers.google.com/youtube/iframe_api_reference#getAvailablePlaybackRates
- */
-function getAvailablePlaybackRates() {
-	return player.value.getAvailablePlaybackRates()
+/** @see https://developers.google.com/youtube/iframe_api_reference#onApiChange */
+function setAnOption(module: string, option: string, value: unknown): void {
+	ensurePlayer().setOption(module, option, value)
 }
 
-/**
- * retrieves an array of module names for which you can set player options
- *
- * @returns {Object}
- * @see https://developers.google.com/youtube/iframe_api_reference#onApiChange
- */
-function getOptions() {
-	return player.value.getOptions()
+/** @see https://developers.google.com/youtube/iframe_api_reference#getSphericalProperties */
+function getSphericalProperties(): object {
+	return ensurePlayer().getSphericalProperties()
 }
 
-/**
- * retrieves the value of a specific player option
- *
- * @param module
- * @param option
- *
- * @return {*}
- * @see https://developers.google.com/youtube/iframe_api_reference#onApiChange
- */
-function getAnOption(module, option) {
-	return player.value.getOption(module, option)
+/** @see https://developers.google.com/youtube/iframe_api_reference#setSphericalProperties */
+function setSphericalProperties(properties: object): void {
+	ensurePlayer().setSphericalProperties(properties)
 }
 
-/**
- * sets the value of a specific player option
- *
- * @param module
- * @param option
- * @param value
- *
- * @returns void
- * @see https://developers.google.com/youtube/iframe_api_reference#onApiChange
- */
-function setAnOption(module, option, value) {
-	player.value.setOption(module, option, value)
+/** @see https://developers.google.com/youtube/iframe_api_reference#getPlaylist */
+function getPlaylist(): string[] {
+	return ensurePlayer().getPlaylist()
 }
 
-/**
- * Retrieves properties that describe the viewer's current perspective, or view, for a video playback
- *
- * @returns {Object} {yaw, pitch, roll, fov}
- * @see https://developers.google.com/youtube/iframe_api_reference#getSphericalProperties
- */
-function getSphericalProperties() {
-	return player.value.getSphericalProperties()
+/** @see https://developers.google.com/youtube/iframe_api_reference#getPlaylistIndex */
+function getPlaylistIndex(): number {
+	return ensurePlayer().getPlaylistIndex()
 }
 
-/**
- * Sets the video orientation for playback of a 360° video
- *
- * @param {Object} props {yaw, pitch, roll, fov, enableOrientationSensor}
- *
- * @returns void
- * @see https://developers.google.com/youtube/iframe_api_reference#setSphericalProperties
- */
-function setSphericalProperties(props) {
-	player.value.setSphericalProperties(props)
+/** @see https://developers.google.com/youtube/iframe_api_reference#getIframe */
+function getIframe(): HTMLIFrameElement {
+	return ensurePlayer().getIframe()
 }
 
-/**
- * @returns {Array}
- * @see https://developers.google.com/youtube/iframe_api_reference#getPlaylist
- */
-function getPlaylist() {
-	return player.value.getPlaylist()
-}
-
-/**
- * @return {Number}
- * @see https://developers.google.com/youtube/iframe_api_reference#getPlaylistIndex
- */
-function getPlaylistIndex() {
-	return player.value.getPlaylistIndex()
-}
-
-/**
- * @return {Object}
- * @see https://developers.google.com/youtube/iframe_api_reference#getIframe
- */
-function getIframe() {
-	return player.value.getIframe()
-}
-
-/**
- * @see https://developers.google.com/youtube/iframe_api_reference#destroy
- */
-function destroy() {
-	player.value.destroy()
-	player.value = null
-}
-
-/**
- * @param {String} videoId
- * @param {Number} startSeconds
- * @param {Number} endSeconds
- *
- * @returns void
- * @see https://developers.google.com/youtube/iframe_api_reference#loadVideoById
- */
-function loadVideoById({videoId, startSeconds, endSeconds} = {}) {
-	player.value.loadVideoById({videoId, startSeconds, endSeconds})
-}
-
-/**
- * @param {String} videoId
- * @param {Number} startSeconds
- * @param {Number} endSeconds
- *
- * @returns void
- * @see https://developers.google.com/youtube/iframe_api_reference#cueVideoById
- */
-function cueVideoById({videoId, startSeconds, endSeconds} = {}) {
-	player.value.cueVideoById({videoId, startSeconds, endSeconds})
-}
-
-/**
- * @param {String} mediaContentUrl
- * @param {Number} startSeconds
- * @param {Number} endSeconds
- *
- * @returns void
- * @see https://developers.google.com/youtube/iframe_api_reference#loadVideoByUrl
- */
-function loadVideoByUrl({mediaContentUrl, startSeconds, endSeconds} = {}) {
-	player.value.loadVideoByUrl({mediaContentUrl, startSeconds, endSeconds})
-}
-
-/**
- * @param {String} mediaContentUrl
- * @param {Number} startSeconds
- * @param {Number} endSeconds
- *
- * @returns void
- * @see https://developers.google.com/youtube/iframe_api_reference#cueVideoByUrl
- */
-function cueVideoByUrl({mediaContentUrl, startSeconds, endSeconds} = {}) {
-	player.value.cueVideoByUrl({mediaContentUrl, startSeconds, endSeconds})
-}
-
-/**
- *
- * @param {String|Array} playlist
- * @param {Number} index
- * @param {Number} startSeconds
- *
- * @returns void
- * @see https://developers.google.com/youtube/iframe_api_reference#cuePlaylist
- */
-function cuePlaylist(playlist, index, startSeconds) {
-	player.value.cuePlaylist(playlist, index, startSeconds)
-}
-
-/**
- * Load a new playlist
- *
- * @param {String|Array} playlist
- * @param {Number} index
- * @param {Number} startSeconds
- *
- * @returns void
- * @see https://developers.google.com/youtube/iframe_api_reference#loadPlaylist
- */
-function loadPlaylist(playlist, index, startSeconds) {
-	player.value.loadPlaylist(playlist, index, startSeconds)
-}
-
-/**
- * Get the video id from a YouTube url
- *
- * Following types of urls are supported:
- * https://www.youtube.com/watch?v=SomE-ID
- * https://youtu.be/SomE-ID
- * https://m.youtube.com/watch?v=SomE-ID
- * https://www.youtube.com/embed/SomE-ID
- *
- * @param url
- *
- * @returns {string|null}
- */
-function getVideoIdFromYoutubeURL(url) {
-	const regex = /^https:\/\/(?:(?:www|m)\.)?(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)(?<id>[a-zA-Z0-9_-]{11})(?:[&?].*)?$/gm
-	regex.lastIndex = 0
-	const match = regex.exec(url)
-	if (match) {
-		return match.groups.id
-	} else {
-		return null
+/** @see https://developers.google.com/youtube/iframe_api_reference#destroy */
+function destroy(): void {
+	if (player.value) {
+		player.value.destroy()
+		player.value = null
 	}
 }
 
-/**
- * Debounce function
- */
-function debounce(func, wait, immediate) {
-	var timeout
-	return function () {
-		var context = this, args = arguments
-		var later = function () {
-			timeout = null
-			if (!immediate) func.apply(context, args)
-		}
-		var callNow = immediate && !timeout
-		clearTimeout(timeout)
-		timeout = setTimeout(later, wait)
-		if (callNow) func.apply(context, args)
-	}
+/** @see https://developers.google.com/youtube/iframe_api_reference#loadVideoById */
+function loadVideoById({videoId, startSeconds, endSeconds}: LoadVideoByIdOptions): void {
+	ensurePlayer().loadVideoById({videoId, startSeconds, endSeconds})
+}
+
+/** @see https://developers.google.com/youtube/iframe_api_reference#cueVideoById */
+function cueVideoById({videoId, startSeconds, endSeconds}: LoadVideoByIdOptions): void {
+	ensurePlayer().cueVideoById({videoId, startSeconds, endSeconds})
+}
+
+/** @see https://developers.google.com/youtube/iframe_api_reference#loadVideoByUrl */
+function loadVideoByUrl({mediaContentUrl, startSeconds, endSeconds}: LoadVideoByUrlOptions): void {
+	ensurePlayer().loadVideoByUrl({mediaContentUrl, startSeconds, endSeconds})
+}
+
+/** @see https://developers.google.com/youtube/iframe_api_reference#cueVideoByUrl */
+function cueVideoByUrl({mediaContentUrl, startSeconds, endSeconds}: LoadVideoByUrlOptions): void {
+	ensurePlayer().cueVideoByUrl({mediaContentUrl, startSeconds, endSeconds})
+}
+
+/** @see https://developers.google.com/youtube/iframe_api_reference#cuePlaylist */
+function cuePlaylist(playlist: string | string[], index?: number, startSeconds?: number): void {
+	ensurePlayer().cuePlaylist(playlist as string, index, startSeconds)
+}
+
+/** @see https://developers.google.com/youtube/iframe_api_reference#loadPlaylist */
+function loadPlaylist(playlist: string | string[], index?: number, startSeconds?: number): void {
+	ensurePlayer().loadPlaylist(playlist as string, index, startSeconds)
 }
 
 defineExpose({
@@ -665,6 +443,6 @@ defineExpose({
 	cueVideoByUrl,
 	cuePlaylist,
 	loadPlaylist,
-	getVideoIdFromYoutubeURL
+	getVideoIdFromYoutubeURL,
 })
 </script>

--- a/lib/VueYtframe.vue
+++ b/lib/VueYtframe.vue
@@ -51,6 +51,20 @@ watch(() => props.videoUrl, (videoUrl) => debouncedUrlChange(videoUrl))
 function onVideoIdChange(videoId: string | null): void {
 	validate()
 	if (!urlValidity.value || !videoId) return
+	loadOrCueById(videoId)
+}
+
+function onVideoUrlChange(videoUrl: string | null): void {
+	validate()
+	if (!urlValidity.value || !videoUrl) return
+	// The YT API's load/cueVideoByUrl only accept the ".../v/ID?version=3"
+	// format, so resolve the ID and reload via the reliable *ById methods.
+	const videoId = getVideoIdFromYoutubeURL(videoUrl)
+	if (videoId) loadOrCueById(videoId)
+}
+
+/** Reloads (autoplay) or cues a video by ID, creating the player if needed. */
+function loadOrCueById(videoId: string): void {
 	if (!player.value) {
 		createPlayer()
 		return
@@ -64,25 +78,6 @@ function onVideoIdChange(videoId: string | null): void {
 		player.value.loadVideoById(args)
 	} else {
 		player.value.cueVideoById(args)
-	}
-}
-
-function onVideoUrlChange(videoUrl: string | null): void {
-	validate()
-	if (!urlValidity.value || !videoUrl) return
-	if (!player.value) {
-		createPlayer()
-		return
-	}
-	const args = {
-		mediaContentUrl: videoUrl,
-		startSeconds: props.playerVars?.start || 0,
-		endSeconds: props.playerVars?.end || undefined,
-	}
-	if (props.playerVars?.autoplay === 1) {
-		player.value.loadVideoByUrl(args)
-	} else {
-		player.value.cueVideoByUrl(args)
 	}
 }
 

--- a/lib/__tests__/VueYtframe.test.ts
+++ b/lib/__tests__/VueYtframe.test.ts
@@ -1,0 +1,258 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+import {flushPromises, mount} from "@vue/test-utils"
+import VueYtframe from "../VueYtframe.vue"
+
+/** Records every constructed player and the event handlers it was given. */
+const players: FakePlayer[] = []
+
+const PLAYER_METHODS = [
+	"playVideo", "pauseVideo", "stopVideo", "seekTo", "nextVideo", "previousVideo",
+	"playVideoAt", "mute", "unMute", "isMuted", "setVolume", "getVolume", "setSize",
+	"setShuffle", "setLoop", "getDuration", "getCurrentTime", "getVideoEmbedCode",
+	"getVideoUrl", "getVideoLoadedFraction", "getPlayerState", "getPlaybackRate",
+	"setPlaybackRate", "getAvailablePlaybackRates", "getOptions", "getOption",
+	"setOption", "getSphericalProperties", "setSphericalProperties", "getPlaylist",
+	"getPlaylistIndex", "getIframe", "destroy", "loadVideoById", "cueVideoById",
+	"loadVideoByUrl", "cueVideoByUrl", "cuePlaylist", "loadPlaylist",
+]
+
+class FakePlayer {
+	el: Element
+	opts: YT.PlayerOptions;
+	[method: string]: ReturnType<typeof vi.fn> | unknown
+
+	constructor(el: Element, opts: YT.PlayerOptions) {
+		this.el = el
+		this.opts = opts
+		for (const name of PLAYER_METHODS) this[name] = vi.fn()
+		this.getVolume = vi.fn(() => 42)
+		players.push(this)
+	}
+
+	fireState(state: number): void {
+		this.opts.events?.onStateChange?.({target: this, data: state} as unknown as YT.OnStateChangeEvent)
+	}
+
+	fireReady(): void {
+		this.opts.events?.onReady?.({target: this} as unknown as YT.PlayerEvent)
+	}
+
+	fireError(): void {
+		this.opts.events?.onError?.({target: this, data: 2} as unknown as YT.OnErrorEvent)
+	}
+}
+
+const PlayerState = {UNSTARTED: -1, ENDED: 0, PLAYING: 1, PAUSED: 2, BUFFERING: 3, CUED: 5}
+
+async function mountReady(props: Record<string, unknown>) {
+	const wrapper = mount(VueYtframe, {props, attachTo: document.body})
+	await flushPromises()
+	return wrapper
+}
+
+beforeEach(() => {
+	players.length = 0
+	vi.stubGlobal("YT", {Player: FakePlayer, PlayerState})
+	vi.spyOn(console, "warn").mockImplementation(() => {})
+})
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+	vi.useRealTimers()
+	vi.restoreAllMocks()
+})
+
+describe("VueYtframe — mounting", () => {
+	it("creates a player with the given videoId, size and playerVars", async () => {
+		await mountReady({videoId: "kGb9ftWR3l8", width: 640, height: 360, playerVars: {rel: 0}})
+
+		expect(players).toHaveLength(1)
+		expect(players[0].opts.videoId).toBe("kGb9ftWR3l8")
+		expect(players[0].opts.width).toBe(640)
+		expect(players[0].opts.height).toBe(360)
+		expect(players[0].opts.playerVars).toEqual({rel: 0})
+	})
+
+	it("derives the videoId from a videoUrl", async () => {
+		await mountReady({videoUrl: "https://youtu.be/kGb9ftWR3l8"})
+		expect(players[0].opts.videoId).toBe("kGb9ftWR3l8")
+	})
+
+	it("does not create a player when neither videoId nor videoUrl is given", async () => {
+		await mountReady({})
+		expect(players).toHaveLength(0)
+	})
+
+	it("does not create a player for an invalid videoUrl", async () => {
+		await mountReady({videoUrl: "https://vimeo.com/123"})
+		expect(players).toHaveLength(0)
+	})
+
+	it("gives up loading after the timeout when the API never appears", async () => {
+		vi.useFakeTimers()
+		vi.stubGlobal("YT", undefined) // API never becomes available
+		// happy-dom can't fetch the real script; no-op the injection.
+		vi.spyOn(document.head, "appendChild").mockImplementation((node) => node)
+		const wrapper = mount(VueYtframe, {props: {videoId: "kGb9ftWR3l8"}, attachTo: document.body})
+
+		await vi.advanceTimersByTimeAsync(10_100)
+
+		expect(players).toHaveLength(0)
+		wrapper.unmount()
+	})
+})
+
+describe("VueYtframe — events", () => {
+	it("emits ready", async () => {
+		const wrapper = await mountReady({videoId: "kGb9ftWR3l8"})
+		players[0].fireReady()
+		expect(wrapper.emitted("ready")).toHaveLength(1)
+	})
+
+	it("maps player states to playing/paused/ended plus stateChange", async () => {
+		const wrapper = await mountReady({videoId: "kGb9ftWR3l8"})
+		const p = players[0]
+
+		p.fireState(PlayerState.PLAYING)
+		p.fireState(PlayerState.PAUSED)
+		p.fireState(PlayerState.ENDED)
+		p.fireState(PlayerState.BUFFERING) // only stateChange, no named event
+
+		expect(wrapper.emitted("playing")).toHaveLength(1)
+		expect(wrapper.emitted("paused")).toHaveLength(1)
+		expect(wrapper.emitted("ended")).toHaveLength(1)
+		expect(wrapper.emitted("stateChange")).toHaveLength(4)
+	})
+
+	it("emits error", async () => {
+		const wrapper = await mountReady({videoId: "kGb9ftWR3l8"})
+		players[0].fireError()
+		expect(wrapper.emitted("error")).toHaveLength(1)
+	})
+})
+
+describe("VueYtframe — lifecycle & methods", () => {
+	it("destroys the player on unmount", async () => {
+		const wrapper = await mountReady({videoId: "kGb9ftWR3l8"})
+		const p = players[0]
+		wrapper.unmount()
+		expect(p.destroy).toHaveBeenCalledTimes(1)
+	})
+
+	const DELEGATIONS: Array<[string, unknown[], string]> = [
+		["playVideo", [], "playVideo"],
+		["pauseVideo", [], "pauseVideo"],
+		["stopVideo", [], "stopVideo"],
+		["seekTo", [10, true], "seekTo"],
+		["nextVideo", [], "nextVideo"],
+		["previousVideo", [], "previousVideo"],
+		["playVideoAt", [0], "playVideoAt"],
+		["mute", [], "mute"],
+		["unMute", [], "unMute"],
+		["isMuted", [], "isMuted"],
+		["setVolume", [50], "setVolume"],
+		["getVolume", [], "getVolume"],
+		["setSize", [100, 50], "setSize"],
+		["setShuffle", [true], "setShuffle"],
+		["setLoop", [true], "setLoop"],
+		["getDuration", [], "getDuration"],
+		["getCurrentTime", [], "getCurrentTime"],
+		["getVideoEmbedCode", [], "getVideoEmbedCode"],
+		["getVideoUrl", [], "getVideoUrl"],
+		["getVideoLoadedFraction", [], "getVideoLoadedFraction"],
+		["getPlayerState", [], "getPlayerState"],
+		["getPlaybackRate", [], "getPlaybackRate"],
+		["setPlaybackRate", [1.5], "setPlaybackRate"],
+		["getAvailablePlaybackRates", [], "getAvailablePlaybackRates"],
+		["getOptions", [], "getOptions"],
+		["getAnOption", ["m", "o"], "getOption"],
+		["setAnOption", ["m", "o", "v"], "setOption"],
+		["getSphericalProperties", [], "getSphericalProperties"],
+		["setSphericalProperties", [{}], "setSphericalProperties"],
+		["getPlaylist", [], "getPlaylist"],
+		["getPlaylistIndex", [], "getPlaylistIndex"],
+		["getIframe", [], "getIframe"],
+		["loadVideoById", [{videoId: "x"}], "loadVideoById"],
+		["cueVideoById", [{videoId: "x"}], "cueVideoById"],
+		["loadVideoByUrl", [{mediaContentUrl: "u"}], "loadVideoByUrl"],
+		["cueVideoByUrl", [{mediaContentUrl: "u"}], "cueVideoByUrl"],
+		["cuePlaylist", [["a"]], "cuePlaylist"],
+		["loadPlaylist", [["a"]], "loadPlaylist"],
+	]
+
+	it.each(DELEGATIONS)("delegates %s() to the underlying player", async (vmMethod, args, playerMethod) => {
+		const wrapper = await mountReady({videoId: "kGb9ftWR3l8"})
+		const vm = wrapper.vm as unknown as Record<string, (...a: unknown[]) => unknown>
+		vm[vmMethod](...args)
+		expect(players[0][playerMethod]).toHaveBeenCalledTimes(1)
+	})
+
+	it("returns values from getter methods", async () => {
+		const wrapper = await mountReady({videoId: "kGb9ftWR3l8"})
+		const vm = wrapper.vm as unknown as {getVolume: () => number}
+		expect(vm.getVolume()).toBe(42)
+	})
+
+	it("throws a clear error when a method is called before the player is ready", async () => {
+		// Not attached to the document: createPlayer can't find its element,
+		// so the player is never instantiated and methods must guard against null.
+		const wrapper = mount(VueYtframe, {props: {videoId: "kGb9ftWR3l8"}})
+		await flushPromises()
+		const vm = wrapper.vm as unknown as {playVideo: () => void}
+		expect(() => vm.playVideo()).toThrow(/not ready/)
+		wrapper.unmount()
+	})
+
+	it("exposes getVideoIdFromYoutubeURL", async () => {
+		const wrapper = await mountReady({videoId: "kGb9ftWR3l8"})
+		const vm = wrapper.vm as unknown as {getVideoIdFromYoutubeURL: (u: string) => string | null}
+		expect(vm.getVideoIdFromYoutubeURL("https://youtu.be/kGb9ftWR3l8")).toBe("kGb9ftWR3l8")
+	})
+
+	it("resizes the player when width/height props change", async () => {
+		const wrapper = await mountReady({videoId: "kGb9ftWR3l8", width: 200, height: 100})
+		await wrapper.setProps({width: 300, height: 150})
+		expect(players[0].setSize).toHaveBeenCalledWith(300, 150)
+	})
+})
+
+describe("VueYtframe — prop changes (debounced)", () => {
+	it("cues a new video by id without autoplay", async () => {
+		vi.useFakeTimers()
+		const wrapper = mount(VueYtframe, {props: {videoId: "kGb9ftWR3l8"}, attachTo: document.body})
+		await vi.runOnlyPendingTimersAsync()
+		const p = players[0]
+
+		wrapper.setProps({videoId: "U_0iZpQPPoA"})
+		await vi.advanceTimersByTimeAsync(300)
+
+		expect(p.cueVideoById).toHaveBeenCalledWith(expect.objectContaining({videoId: "U_0iZpQPPoA"}))
+		expect(p.loadVideoById).not.toHaveBeenCalled()
+	})
+
+	it("loads (autoplays) a new video by id when autoplay is set", async () => {
+		vi.useFakeTimers()
+		const wrapper = mount(VueYtframe, {props: {videoId: "kGb9ftWR3l8", playerVars: {autoplay: 1}}, attachTo: document.body})
+		await vi.runOnlyPendingTimersAsync()
+		const p = players[0]
+
+		wrapper.setProps({videoId: "U_0iZpQPPoA"})
+		await vi.advanceTimersByTimeAsync(300)
+
+		expect(p.loadVideoById).toHaveBeenCalledWith(expect.objectContaining({videoId: "U_0iZpQPPoA"}))
+	})
+
+	it("cues a new video by url", async () => {
+		vi.useFakeTimers()
+		const wrapper = mount(VueYtframe, {props: {videoUrl: "https://youtu.be/kGb9ftWR3l8"}, attachTo: document.body})
+		await vi.runOnlyPendingTimersAsync()
+		const p = players[0]
+
+		wrapper.setProps({videoUrl: "https://youtu.be/U_0iZpQPPoA"})
+		await vi.advanceTimersByTimeAsync(500)
+
+		expect(p.cueVideoByUrl).toHaveBeenCalledWith(
+			expect.objectContaining({mediaContentUrl: "https://youtu.be/U_0iZpQPPoA"}),
+		)
+	})
+})

--- a/lib/__tests__/VueYtframe.test.ts
+++ b/lib/__tests__/VueYtframe.test.ts
@@ -242,7 +242,9 @@ describe("VueYtframe — prop changes (debounced)", () => {
 		expect(p.loadVideoById).toHaveBeenCalledWith(expect.objectContaining({videoId: "U_0iZpQPPoA"}))
 	})
 
-	it("cues a new video by url", async () => {
+	it("reloads by resolved id when the videoUrl changes", async () => {
+		// load/cueVideoByUrl only accept the ".../v/ID?version=3" format, so a
+		// changed watch/short URL must reload via cueVideoById to actually work.
 		vi.useFakeTimers()
 		const wrapper = mount(VueYtframe, {props: {videoUrl: "https://youtu.be/kGb9ftWR3l8"}, attachTo: document.body})
 		await vi.runOnlyPendingTimersAsync()
@@ -251,8 +253,9 @@ describe("VueYtframe — prop changes (debounced)", () => {
 		wrapper.setProps({videoUrl: "https://youtu.be/U_0iZpQPPoA"})
 		await vi.advanceTimersByTimeAsync(500)
 
-		expect(p.cueVideoByUrl).toHaveBeenCalledWith(
-			expect.objectContaining({mediaContentUrl: "https://youtu.be/U_0iZpQPPoA"}),
+		expect(p.cueVideoById).toHaveBeenCalledWith(
+			expect.objectContaining({videoId: "U_0iZpQPPoA"}),
 		)
+		expect(p.cueVideoByUrl).not.toHaveBeenCalled()
 	})
 })

--- a/lib/__tests__/docs-drift.test.ts
+++ b/lib/__tests__/docs-drift.test.ts
@@ -1,0 +1,32 @@
+import {readFileSync} from "node:fs"
+import {resolve} from "node:path"
+import {describe, expect, it} from "vitest"
+import {ComponentMethods} from "../../src/helper.js"
+
+/**
+ * Guards against the docs site drifting from the component's real public API.
+ * If a method is added to / removed from `defineExpose` but the docs Methods
+ * table isn't updated to match (or vice versa), this test fails.
+ */
+describe("docs Methods table vs component defineExpose", () => {
+	const documented = (ComponentMethods.table.rows as Array<[string, string]>)
+		.map((row) => row[0].split("(")[0].trim())
+
+	const source = readFileSync(resolve(process.cwd(), "lib/VueYtframe.vue"), "utf8")
+	const exposeBlock = source.match(/defineExpose\(\{([\s\S]*?)\}\)/)?.[1] ?? ""
+	const exposed = exposeBlock
+		.split(",")
+		.map((name) => name.trim())
+		.filter(Boolean)
+		.filter((name) => name !== "player") // a ref, not a documented method
+
+	it("documents every exposed method", () => {
+		const undocumented = exposed.filter((name) => !documented.includes(name))
+		expect(undocumented, "methods exposed but missing from the docs table").toEqual([])
+	})
+
+	it("does not document methods that are not exposed", () => {
+		const phantom = documented.filter((name) => !exposed.includes(name))
+		expect(phantom, "methods in the docs table that are not exposed").toEqual([])
+	})
+})

--- a/lib/__tests__/index.test.ts
+++ b/lib/__tests__/index.test.ts
@@ -1,0 +1,16 @@
+import {describe, expect, it} from "vitest"
+import {createApp} from "vue"
+import plugin, {VueYtframe, getVideoIdFromYoutubeURL} from "../index"
+
+describe("plugin entry", () => {
+	it("registers VueYtframe globally when installed", () => {
+		const app = createApp({template: "<div />"})
+		app.use(plugin)
+		expect(app.component("VueYtframe")).toBeTruthy()
+	})
+
+	it("re-exports the component and the url helper", () => {
+		expect(VueYtframe).toBeTruthy()
+		expect(getVideoIdFromYoutubeURL("https://youtu.be/kGb9ftWR3l8")).toBe("kGb9ftWR3l8")
+	})
+})

--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -1,0 +1,79 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+import {debounce, getVideoIdFromYoutubeURL} from "../utils"
+
+describe("getVideoIdFromYoutubeURL", () => {
+	const ID = "kGb9ftWR3l8"
+
+	it.each([
+		["watch", `https://www.youtube.com/watch?v=${ID}`],
+		["watch no www", `https://youtube.com/watch?v=${ID}`],
+		["watch mobile", `https://m.youtube.com/watch?v=${ID}`],
+		["watch http", `http://www.youtube.com/watch?v=${ID}`],
+		["watch v not first", `https://www.youtube.com/watch?list=PL123&v=${ID}`],
+		["watch with extra params", `https://www.youtube.com/watch?v=${ID}&t=30s`],
+		["short link", `https://youtu.be/${ID}`],
+		["short link with query", `https://youtu.be/${ID}?t=10`],
+		["embed", `https://www.youtube.com/embed/${ID}`],
+		["shorts", `https://www.youtube.com/shorts/${ID}`],
+		["live", `https://www.youtube.com/live/${ID}`],
+		["v path", `https://www.youtube.com/v/${ID}`],
+		["nocookie embed", `https://www.youtube-nocookie.com/embed/${ID}`],
+	])("extracts the id from a %s URL", (_label, url) => {
+		expect(getVideoIdFromYoutubeURL(url)).toBe(ID)
+	})
+
+	it.each([
+		["empty string", ""],
+		["null", null],
+		["undefined", undefined],
+		["not a url", "kGb9ftWR3l8"],
+		["non-youtube host", "https://vimeo.com/watch?v=kGb9ftWR3l8"],
+		["watch without v", "https://www.youtube.com/watch?list=PL123"],
+		["too-short id", "https://youtu.be/short"],
+		["ftp protocol", "ftp://www.youtube.com/watch?v=kGb9ftWR3l8"],
+	])("returns null for %s", (_label, url) => {
+		expect(getVideoIdFromYoutubeURL(url as string)).toBeNull()
+	})
+})
+
+describe("debounce", () => {
+	beforeEach(() => vi.useFakeTimers())
+	afterEach(() => vi.useRealTimers())
+
+	it("invokes the function only once after rapid calls", () => {
+		const fn = vi.fn()
+		const debounced = debounce(fn, 300)
+
+		debounced("a")
+		debounced("b")
+		debounced("c")
+		expect(fn).not.toHaveBeenCalled()
+
+		vi.advanceTimersByTime(300)
+		expect(fn).toHaveBeenCalledTimes(1)
+		expect(fn).toHaveBeenCalledWith("c")
+	})
+
+	it("invokes again after the wait elapses between calls", () => {
+		const fn = vi.fn()
+		const debounced = debounce(fn, 100)
+
+		debounced("first")
+		vi.advanceTimersByTime(100)
+		debounced("second")
+		vi.advanceTimersByTime(100)
+
+		expect(fn).toHaveBeenCalledTimes(2)
+	})
+
+	it("cancel() prevents a pending invocation", () => {
+		const fn = vi.fn()
+		const debounced = debounce(fn, 200)
+
+		debounced("x")
+		debounced.cancel()
+		vi.advanceTimersByTime(500)
+
+		expect(fn).not.toHaveBeenCalled()
+	})
+})

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,19 @@
+/** Matches a canonical 11-character YouTube video ID. */
+export const VIDEO_ID = /^[a-zA-Z0-9_-]{11}$/
+
+/** Strips optional `www.` or `m.` from a YouTube hostname. */
+export const YOUTUBE_HOST_PREFIX = /^(www\.|m\.)/
+
+/** Path segments: `/embed|shorts|live|v/<id>`. Capture group 1 is the video ID. */
+export const YOUTUBE_EMBED_PATH = /^\/(?:embed|shorts|live|v)\/([a-zA-Z0-9_-]{11})/
+
+export const YOUTUBE_HOST_YOUTU_BE = "youtu.be"
+export const YOUTUBE_HOST_YOUTUBE_COM = "youtube.com"
+export const YOUTUBE_HOST_NOCOOKIE = "youtube-nocookie.com"
+
+/** YouTube Iframe API script source URL. */
+export const YT_API_SRC = "https://www.youtube.com/iframe_api"
+/** YouTube Iframe API load timeout in milliseconds. */
+export const YT_LOAD_TIMEOUT = 10_000
+/** YouTube Iframe API poll interval in milliseconds. */
+export const YT_POLL_INTERVAL = 100

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,0 @@
-import VueYtframe from "./VueYtframe.vue"
-
-export default {
-	// eslint-disable-next-line no-unused-vars
-	install: (app, options) => {
-		app.component("VueYtframe", VueYtframe)
-	}
-}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,0 +1,37 @@
+import type {App, Plugin} from "vue"
+import VueYtframe from "./VueYtframe.vue"
+
+export {VueYtframe}
+export type {
+	VueYtframeProps,
+	VueYtframeEmits,
+	VueYtframeInstance,
+	LoadVideoByIdOptions,
+	LoadVideoByUrlOptions,
+} from "./types"
+export {getVideoIdFromYoutubeURL} from "./utils"
+
+/**
+ * Vue plugin that registers `<VueYtframe>` globally.
+ *
+ * @example
+ * import VueYtframe from "vue3-ytframe"
+ * app.use(VueYtframe)
+ *
+ * @example
+ * // or register locally
+ * import { VueYtframe } from "vue3-ytframe"
+ */
+const plugin: Plugin = {
+	install(app: App) {
+		app.component("VueYtframe", VueYtframe)
+	},
+}
+
+export default plugin
+
+declare module "vue" {
+	export interface GlobalComponents {
+		VueYtframe: typeof VueYtframe
+	}
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,89 @@
+import type {Ref} from "vue"
+
+/** Props accepted by the `<VueYtframe>` component. */
+export interface VueYtframeProps {
+	/** YouTube video ID. One of `videoId` or `videoUrl` must be provided. */
+	videoId?: string | null
+	/** Full YouTube video URL (parsed to a video ID internally). */
+	videoUrl?: string | null
+	/** Player width in pixels or a CSS size. Defaults to `"100%"`. */
+	width?: number | string
+	/** Player height in pixels or a CSS size. Defaults to `"100%"`. */
+	height?: number | string
+	/** YouTube Iframe API player parameters. */
+	playerVars?: YT.PlayerVars
+}
+
+/** Event map emitted by `<VueYtframe>`. Each payload is the underlying `YT.Player`. */
+export type VueYtframeEmits = {
+	ready: [player: YT.Player]
+	playing: [player: YT.Player]
+	paused: [player: YT.Player]
+	ended: [player: YT.Player]
+	stateChange: [player: YT.Player]
+	playbackQualityChange: [player: YT.Player]
+	playbackRateChange: [player: YT.Player]
+	error: [player: YT.Player]
+	apiChange: [player: YT.Player]
+}
+
+export interface LoadVideoByIdOptions {
+	videoId: string
+	startSeconds?: number
+	endSeconds?: number
+}
+
+export interface LoadVideoByUrlOptions {
+	mediaContentUrl: string
+	startSeconds?: number
+	endSeconds?: number
+}
+
+/**
+ * The methods and refs exposed by a `<VueYtframe>` instance via a template ref.
+ * Use it to type your ref: `const yt = ref<VueYtframeInstance>()`.
+ */
+export interface VueYtframeInstance {
+	/** The underlying `YT.Player`, or `null` until the player is ready. */
+	player: Ref<YT.Player | null>
+	playVideo(): void
+	pauseVideo(): void
+	stopVideo(): void
+	seekTo(seconds: number, allowSeekAhead: boolean): void
+	nextVideo(): void
+	previousVideo(): void
+	playVideoAt(index: number): void
+	mute(): void
+	unMute(): void
+	isMuted(): boolean
+	setVolume(volume: number): void
+	getVolume(): number
+	setSize(width: number, height: number): void
+	setShuffle(shufflePlaylist: boolean): void
+	setLoop(loopPlaylists: boolean): void
+	getDuration(): number
+	getCurrentTime(): number
+	getVideoEmbedCode(): string
+	getVideoUrl(): string
+	getVideoLoadedFraction(): number
+	getPlayerState(): number
+	getPlaybackRate(): number
+	setPlaybackRate(suggestedRate: number): void
+	getAvailablePlaybackRates(): number[]
+	getOptions(): string[]
+	getAnOption(module: string, option: string): unknown
+	setAnOption(module: string, option: string, value: unknown): void
+	getSphericalProperties(): object
+	setSphericalProperties(props: object): void
+	getPlaylist(): string[]
+	getPlaylistIndex(): number
+	getIframe(): HTMLIFrameElement
+	destroy(): void
+	loadVideoById(options: LoadVideoByIdOptions): void
+	cueVideoById(options: LoadVideoByIdOptions): void
+	loadVideoByUrl(options: LoadVideoByUrlOptions): void
+	cueVideoByUrl(options: LoadVideoByUrlOptions): void
+	cuePlaylist(playlist: string | string[], index?: number, startSeconds?: number): void
+	loadPlaylist(playlist: string | string[], index?: number, startSeconds?: number): void
+	getVideoIdFromYoutubeURL(url: string | null | undefined): string | null
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,86 @@
+import {
+	VIDEO_ID,
+	YOUTUBE_EMBED_PATH,
+	YOUTUBE_HOST_PREFIX,
+	YOUTUBE_HOST_NOCOOKIE,
+	YOUTUBE_HOST_YOUTU_BE,
+	YOUTUBE_HOST_YOUTUBE_COM,
+} from "./constants"
+
+/** Dev-only diagnostic; the published library stays silent in production. */
+export function warn(...args: unknown[]): void {
+	if (import.meta.env.DEV) console.warn("[vue3-ytframe]", ...args)
+}
+
+/**
+ * A debounced version of `fn` that delays invocation until `wait` ms have
+ * elapsed since the last call. The returned function keeps a single shared
+ * timer across calls (so rapid calls genuinely coalesce) and exposes
+ * `cancel()` to clear a pending invocation — used on component teardown.
+ */
+export function debounce<A extends unknown[]>(
+	fn: (...args: A) => void,
+	wait: number,
+): ((...args: A) => void) & {cancel: () => void} {
+	let timeout: ReturnType<typeof setTimeout> | undefined
+
+	const debounced = (...args: A): void => {
+		if (timeout) clearTimeout(timeout)
+		timeout = setTimeout(() => {
+			timeout = undefined
+			fn(...args)
+		}, wait)
+	}
+
+	debounced.cancel = (): void => {
+		if (timeout) clearTimeout(timeout)
+		timeout = undefined
+	}
+
+	return debounced
+}
+
+/**
+ * Extracts the 11-character video ID from a YouTube URL, or returns `null`
+ * when the input is not a recognizable YouTube URL.
+ *
+ * Supported forms (http or https, optional `www.`/`m.`):
+ * - `youtube.com/watch?v=<id>` (the `v` param may appear in any position)
+ * - `youtu.be/<id>`
+ * - `youtube.com/embed/<id>`
+ * - `youtube.com/shorts/<id>`
+ * - `youtube.com/live/<id>`
+ * - `youtube.com/v/<id>`
+ * - `youtube-nocookie.com/embed/<id>`
+ */
+export function getVideoIdFromYoutubeURL(url: string | null | undefined): string | null {
+	if (!url || typeof url !== "string") return null
+
+	let parsed: URL
+	try {
+		parsed = new URL(url.trim())
+	} catch {
+		return null
+	}
+
+	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null
+
+	const host = parsed.hostname.replace(YOUTUBE_HOST_PREFIX, "")
+	const path = parsed.pathname
+
+	if (host === YOUTUBE_HOST_YOUTU_BE) {
+		const id = path.slice(1).split("/")[0]
+		return VIDEO_ID.test(id) ? id : null
+	}
+
+	if (host === YOUTUBE_HOST_YOUTUBE_COM || host === YOUTUBE_HOST_NOCOOKIE) {
+		if (path === "/watch") {
+			const v = parsed.searchParams.get("v")
+			return v && VIDEO_ID.test(v) ? v : null
+		}
+		const match = YOUTUBE_EMBED_PATH.exec(path)
+		if (match) return match[1]
+	}
+
+	return null
+}

--- a/lib/youtube.d.ts
+++ b/lib/youtube.d.ts
@@ -1,0 +1,18 @@
+// Augments @types/youtube with the module-options API, which the YouTube
+// Iframe API exposes but the published typings omit.
+// @see https://developers.google.com/youtube/iframe_api_reference#onApiChange
+
+export {}
+
+declare global {
+	namespace YT {
+		interface Player {
+			/** Returns the module names for which options can be set. */
+			getOptions(): string[]
+			/** Returns the value of a specific module option. */
+			getOption(module: string, option: string): unknown
+			/** Sets the value of a specific module option. */
+			setOption(module: string, option: string, value: unknown): void
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vue3-ytframe",
-	"version": "0.4.4",
+	"version": "1.0.0",
 	"author": "Kiran Parajuli <kiranparajuli589@gmail.com>",
 	"description": "A Vue3 YouTube Iframe API Wrapper Component",
 	"type": "module",
@@ -20,14 +20,19 @@
 	"unpkg": "dist/ytframe.umd.cjs",
 	"jsdelivr": "dist/ytframe.umd.cjs",
 	"module": "dist/ytframe.es.js",
+	"types": "dist/lib/index.d.ts",
 	"exports": {
 		".": {
+			"types": "./dist/lib/index.d.ts",
 			"import": "./dist/ytframe.es.js",
 			"require": "./dist/ytframe.umd.cjs",
 			"default": "./dist/ytframe.es.js"
 		}
 	},
 	"sideEffects": false,
+	"dependencies": {
+		"@types/youtube": "^0.2.0"
+	},
 	"peerDependencies": {
 		"vue": "^3.5.0"
 	},
@@ -42,6 +47,7 @@
 	"engines": {
 		"node": ">=20.19.0"
 	},
+	"packageManager": "pnpm@10.33.2",
 	"pnpm": {
 		"onlyBuiltDependencies": [
 			"@parcel/watcher",
@@ -54,18 +60,27 @@
 		"build-docs": "vite build --mode docs",
 		"build": "pnpm build-lib && pnpm build-docs",
 		"preview": "vite preview",
+		"typecheck": "vue-tsc --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest",
+		"test:coverage": "vitest run --coverage",
 		"lint": "eslint src lib",
 		"lint:fix": "eslint src lib --fix",
-		"stylelint": "stylelint \"src/**/*.{vue,scss,css}\" lib --config stylelint.conf.cjs",
-		"stylelint:fix": "stylelint \"src/**/*.{vue,scss,css}\" lib --config stylelint.conf.cjs --fix"
+		"stylelint": "stylelint \"src/**/*.{vue,scss,css}\" \"lib/**/*.{vue,scss,css}\" --config stylelint.conf.cjs",
+		"stylelint:fix": "stylelint \"src/**/*.{vue,scss,css}\" \"lib/**/*.{vue,scss,css}\" --config stylelint.conf.cjs --fix"
 	},
 	"devDependencies": {
 		"@eslint/js": "^10.0.1",
 		"@mdi/font": "^7.4.47",
+		"@microsoft/api-extractor": "^7.58.7",
+		"@types/node": "^25.9.1",
 		"@vitejs/plugin-vue": "^6.0.7",
+		"@vitest/coverage-v8": "^4.1.8",
+		"@vue/test-utils": "^2.4.10",
 		"eslint": "^10.4.1",
 		"eslint-plugin-vue": "^10.9.2",
 		"globals": "^16.0.0",
+		"happy-dom": "^20.9.0",
 		"highlight.js": "^11.11.1",
 		"pinia": "^3.0.4",
 		"postcss-html": "^1.8.1",
@@ -73,10 +88,15 @@
 		"stylelint": "^17.12.0",
 		"stylelint-config-recommended-vue": "^1.6.1",
 		"stylelint-config-standard-scss": "^17.0.0",
+		"typescript": "^6.0.3",
+		"typescript-eslint": "^8.60.1",
 		"vite": "^8.0.16",
+		"vite-plugin-dts": "^5.0.2",
+		"vitest": "^4.1.8",
 		"vue": "^3.5.35",
 		"vue-eslint-parser": "^10.3.0",
-		"vue-router": "^5.1.0"
+		"vue-router": "^5.1.0",
+		"vue-tsc": "^3.3.3"
 	},
 	"license": "GPL-3.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@types/youtube':
+        specifier: ^0.2.0
+        version: 0.2.0
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -14,24 +18,39 @@ importers:
       '@mdi/font':
         specifier: ^7.4.47
         version: 7.4.47
+      '@microsoft/api-extractor':
+        specifier: ^7.58.7
+        version: 7.58.7(@types/node@25.9.1)
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
       '@vitejs/plugin-vue':
         specifier: ^6.0.7
-        version: 6.0.7(vite@8.0.16(sass@1.100.0)(yaml@2.9.0))(vue@3.5.35)
+        version: 6.0.7(vite@8.0.16(@types/node@25.9.1)(sass@1.100.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
+      '@vue/test-utils':
+        specifier: ^2.4.10
+        version: 2.4.10(@vue/compiler-dom@3.5.35)(@vue/server-renderer@3.5.35(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))
       eslint:
         specifier: ^10.4.1
         version: 10.4.1
       eslint-plugin-vue:
         specifier: ^10.9.2
-        version: 10.9.2(eslint@10.4.1)(vue-eslint-parser@10.4.1(eslint@10.4.1))
+        version: 10.9.2(@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3))(eslint@10.4.1)(vue-eslint-parser@10.4.1(eslint@10.4.1))
       globals:
         specifier: ^16.0.0
         version: 16.5.0
+      happy-dom:
+        specifier: ^20.9.0
+        version: 20.9.0
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
       pinia:
         specifier: ^3.0.4
-        version: 3.0.4(vue@3.5.35)
+        version: 3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3))
       postcss-html:
         specifier: ^1.8.1
         version: 1.8.1
@@ -40,25 +59,40 @@ importers:
         version: 1.100.0
       stylelint:
         specifier: ^17.12.0
-        version: 17.12.0
+        version: 17.12.0(typescript@6.0.3)
       stylelint-config-recommended-vue:
         specifier: ^1.6.1
-        version: 1.6.1(postcss-html@1.8.1)(stylelint@17.12.0)
+        version: 1.6.1(postcss-html@1.8.1)(stylelint@17.12.0(typescript@6.0.3))
       stylelint-config-standard-scss:
         specifier: ^17.0.0
-        version: 17.0.0(postcss@8.5.15)(stylelint@17.12.0)
+        version: 17.0.0(postcss@8.5.15)(stylelint@17.12.0(typescript@6.0.3))
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      typescript-eslint:
+        specifier: ^8.60.1
+        version: 8.60.1(eslint@10.4.1)(typescript@6.0.3)
       vite:
         specifier: ^8.0.16
-        version: 8.0.16(sass@1.100.0)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.1)(sass@1.100.0)(yaml@2.9.0)
+      vite-plugin-dts:
+        specifier: ^5.0.2
+        version: 5.0.2(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(rolldown@1.0.3)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(sass@1.100.0)(yaml@2.9.0))
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(vite@8.0.16(@types/node@25.9.1)(sass@1.100.0)(yaml@2.9.0))
       vue:
         specifier: ^3.5.35
-        version: 3.5.35
+        version: 3.5.35(typescript@6.0.3)
       vue-eslint-parser:
         specifier: ^10.3.0
         version: 10.4.1(eslint@10.4.1)
       vue-router:
         specifier: ^5.1.0
-        version: 5.1.0(@vue/compiler-sfc@3.5.35)(pinia@3.0.4(vue@3.5.35))(vite@8.0.16(sass@1.100.0)(yaml@2.9.0))(vue@3.5.35)
+        version: 5.1.0(@vue/compiler-sfc@3.5.35)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(vite@8.0.16(@types/node@25.9.1)(sass@1.100.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
+      vue-tsc:
+        specifier: ^3.3.3
+        version: 3.3.3(typescript@6.0.3)
 
 packages:
 
@@ -115,6 +149,10 @@ packages:
   '@babel/types@8.0.0-rc.6':
     resolution: {integrity: sha512-p7/ABylAYlexb31wtRdIfH9L9A0Z2T/9H6zAqzqndkY2PLkvNNc580wGhp/gGKN4Sp9sQvSkhc6Oga8/O+wTyw==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@cacheable/memory@2.0.9':
     resolution: {integrity: sha512-HdMx6DoGywB30vacDbBsITbIX4pgFqj1zsrV58jZBUw3klzkNoXhj7qOqAgledhxG7YZI5rBSJg7Zp8/VG0DuA==}
@@ -240,6 +278,10 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -271,6 +313,19 @@ packages:
   '@mdi/font@7.4.47':
     resolution: {integrity: sha512-43MtGpd585SNzHZPcYowu/84Vz2a2g31TvPMTm9uTiCSWzaheQySUcSyUH/46fPnuPQWof2yd0pGBtzee/IQWw==}
 
+  '@microsoft/api-extractor-model@7.33.8':
+    resolution: {integrity: sha512-aIcoQggPyer3B6Ze3usz0YWC/oBwUHfRH5ETUsr+oT2BRA6SfTJl7IKPcPZkX4UR+PohowzW4uMxsvjrn8vm+w==}
+
+  '@microsoft/api-extractor@7.58.7':
+    resolution: {integrity: sha512-yK6OycD46gIzLRpj6ueVUWPk1ACSpkN1LBo05gY1qPTylbWyUCanXfH7+VgkI5LJrJoRSQR5F04XuCffCXLOBw==}
+    hasBin: true
+
+  '@microsoft/tsdoc-config@0.18.1':
+    resolution: {integrity: sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==}
+
+  '@microsoft/tsdoc@0.16.0':
+    resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
+
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
     peerDependencies:
@@ -288,6 +343,9 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@one-ini/wasm@0.1.1':
+    resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
@@ -379,6 +437,10 @@ packages:
   '@parcel/watcher@2.5.6':
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
@@ -478,12 +540,63 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@rollup/pluginutils@5.4.0':
+    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rushstack/node-core-library@5.23.1':
+    resolution: {integrity: sha512-wlKmIKIYCKuCASbITvOxLZXepPbwXvrv7S6ig6XNWFchSyhL/E2txmVXspHY49Wu2dzf7nI27a2k/yV5BA3EiA==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@rushstack/problem-matcher@0.2.1':
+    resolution: {integrity: sha512-gulfhBs6n+I5b7DvjKRfhMGyUejtSgOHTclF/eONr8hcgF1APEDjhxIsfdUYYMzC3rvLwGluqLjbwCFZ8nxrog==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@rushstack/rig-package@0.7.3':
+    resolution: {integrity: sha512-aAA518n6wxxjCfnTAOjQnm7ngNE0FVHxHAw2pxKlIhxrMn0XQjGcXKF0oKWpjBgJOmsaJpVob/v+zr3zxgPWuA==}
+
+  '@rushstack/terminal@0.24.0':
+    resolution: {integrity: sha512-8ZQS4MMaGsv27EXCBiH7WMPkRZrffeDoIevs6z9TM5dzqiY6+Hn4evfK/G+gvgBTjfvfkHIZPQQmalmI2sM4TQ==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@rushstack/ts-command-line@5.3.9':
+    resolution: {integrity: sha512-GIHqU+sRGQ3LGWAZu1O+9Yh++qwtyNIIGuNbcWHJjBTm2qRez0cwINUHZ+pQLR8UuzZDcMajrDaNbUYoaL/XtQ==}
+
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/argparse@1.0.38':
+    resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -497,12 +610,130 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@types/youtube@0.2.0':
+    resolution: {integrity: sha512-Y+y6RKuqhurm5yWfUt3eT2QdHZNl09+OT86I2yOKGfJzTZCaR5eSf6m7zIGnlUHiUuYm4i/hUTDJ++E53OVh0g==}
+
+  '@typescript-eslint/eslint-plugin@8.60.1':
+    resolution: {integrity: sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.60.1
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.60.1':
+    resolution: {integrity: sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.60.1':
+    resolution: {integrity: sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.60.1':
+    resolution: {integrity: sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.60.1':
+    resolution: {integrity: sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.60.1':
+    resolution: {integrity: sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.60.1':
+    resolution: {integrity: sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.60.1':
+    resolution: {integrity: sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.60.1':
+    resolution: {integrity: sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.60.1':
+    resolution: {integrity: sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@vitejs/plugin-vue@6.0.7':
     resolution: {integrity: sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
+
+  '@vitest/coverage-v8@4.1.8':
+    resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
+    peerDependencies:
+      '@vitest/browser': 4.1.8
+      vitest: 4.1.8
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+
+  '@volar/language-core@2.4.28':
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
+
+  '@volar/source-map@2.4.28':
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
+
+  '@volar/typescript@2.4.28':
+    resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
 
   '@vue-macros/common@3.1.2':
     resolution: {integrity: sha512-h9t4ArDdniO9ekYHAD95t9AZcAbb19lEGK+26iAjUODOIJKmObDNBSe4+6ELQAA3vtYiFPPBtHh7+cQCKi3Dng==}
@@ -543,6 +774,9 @@ packages:
   '@vue/devtools-shared@8.1.2':
     resolution: {integrity: sha512-X9RyVFYAdkBe4IUf5v48TxBF/6QPmF8CmWrDAjXzfUHrgQ/HGfTC1A6TqgXqZ03ye66l3AD51BAGD69IvKM9sw==}
 
+  '@vue/language-core@3.3.3':
+    resolution: {integrity: sha512-X6p+7nfY7vVT6dQwUJ+v0Jfq/lwIfhL2jMi91dQ3ln4hnlGXlxsDu/FNkeyHYgvYtyQy18ZX76IZy7X4diDbiQ==}
+
   '@vue/reactivity@3.5.35':
     resolution: {integrity: sha512-tVc+SsHConvh/Lz64qq1pP3rYArBmK42xonovEcxY74SQtvctZodG/zhq54P5dr38cVuw25d27cPNRdlMidpGQ==}
 
@@ -560,6 +794,20 @@ packages:
   '@vue/shared@3.5.35':
     resolution: {integrity: sha512-zSbjL7gRXwks2ZQLRGCajBtBXEOXW9Ddhn/HvSdrGkE2dqGnumzW8XtusRrxrE9LvqtiqDXQ+A60Hp6mvdYxfA==}
 
+  '@vue/test-utils@2.4.10':
+    resolution: {integrity: sha512-SmoZ5EA1kYiAFs9NkYdiFFQF+cSnUwnvlYEbY+DogWQZUiqOm/Y29eSbc5T6yi75SgSF9863SBeXniIEoPajCA==}
+    peerDependencies:
+      '@vue/compiler-dom': 3.x
+      '@vue/server-renderer': 3.x
+      vue: 3.x
+    peerDependenciesMeta:
+      '@vue/server-renderer':
+        optional: true
+
+  abbrev@2.0.0:
+    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -570,11 +818,33 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ajv@8.12.0:
     resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  alien-signals@3.2.1:
+    resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -592,12 +862,26 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-kit@2.2.0:
     resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
     engines: {node: '>=20.19.0'}
+
+  ast-v8-to-istanbul@1.0.3:
+    resolution: {integrity: sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==}
 
   ast-walker-scope@0.9.0:
     resolution: {integrity: sha512-IJdzo2vLiElBxKzwS36VsCue/62d6IdWjnPB2v3nuPKeWGynp6FF/CYoLa5i/3jXH/z97ZDdsXz6abpgM6w07A==}
@@ -606,6 +890,9 @@ packages:
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -616,6 +903,9 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  brace-expansion@2.1.1:
+    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -631,6 +921,10 @@ packages:
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -656,11 +950,24 @@ packages:
   colord@2.9.3:
     resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
 
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+
+  compare-versions@6.1.1:
+    resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
+
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
+  config-chain@1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   copy-anything@4.0.5:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
@@ -720,6 +1027,10 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
@@ -733,8 +1044,19 @@ packages:
   domutils@3.1.0:
     resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  editorconfig@1.0.7:
+    resolution: {integrity: sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -750,6 +1072,13 @@ packages:
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
@@ -814,9 +1143,16 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -833,6 +1169,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -878,10 +1217,21 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  fs-extra@11.3.5:
+    resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
+    engines: {node: '>=14.14'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
@@ -894,6 +1244,11 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
 
   global-modules@2.0.0:
     resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
@@ -914,9 +1269,20 @@ packages:
   globjoin@0.1.4:
     resolution: {integrity: sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==}
 
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  happy-dom@20.9.0:
+    resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
+    engines: {node: '>=20.0.0'}
+
   has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
 
   has-flag@5.0.1:
     resolution: {integrity: sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==}
@@ -925,6 +1291,10 @@ packages:
   hashery@1.5.1:
     resolution: {integrity: sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==}
     engines: {node: '>=20'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
 
   highlight.js@11.11.1:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
@@ -938,6 +1308,9 @@ packages:
 
   hookified@2.2.0:
     resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-tags@5.1.0:
     resolution: {integrity: sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==}
@@ -961,6 +1334,10 @@ packages:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
     engines: {node: '>=6'}
 
+  import-lazy@4.0.0:
+    resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
+    engines: {node: '>=8'}
+
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
@@ -973,6 +1350,10 @@ packages:
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1004,6 +1385,35 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jju@1.4.0:
+    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
+
+  js-beautify@1.15.4:
+    resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  js-cookie@3.0.8:
+    resolution: {integrity: sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1040,6 +1450,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -1052,6 +1465,9 @@ packages:
 
   known-css-properties@0.37.0:
     resolution: {integrity: sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==}
+
+  kolorist@1.8.0:
+    resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -1145,6 +1561,9 @@ packages:
   lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
@@ -1155,6 +1574,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   mathml-tag-names@4.0.0:
     resolution: {integrity: sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==}
@@ -1174,9 +1600,21 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  minimatch@10.2.3:
+    resolution: {integrity: sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
@@ -1204,12 +1642,20 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
+  nopt@7.2.1:
+    resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
+
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
@@ -1223,6 +1669,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -1231,6 +1680,9 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1238,6 +1690,13 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1317,6 +1776,9 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  proto-list@1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1342,6 +1804,11 @@ packages:
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
 
   reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
@@ -1371,6 +1838,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   semver@7.8.1:
     resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
     engines: {node: '>=10'}
@@ -1383,6 +1855,9 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -1404,13 +1879,34 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
   speakingurl@14.0.1:
     resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
     engines: {node: '>=0.10.0'}
 
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
 
   string-width@8.2.1:
     resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
@@ -1499,9 +1995,21 @@ packages:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
   supports-hyperlinks@4.4.0:
     resolution: {integrity: sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==}
     engines: {node: '>=20'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
 
   svg-tags@1.0.0:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
@@ -1510,13 +2018,30 @@ packages:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
     engines: {node: '>=10.0.0'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1525,16 +2050,74 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  typescript-eslint@8.60.1:
+    resolution: {integrity: sha512-6m5hkkRAp8lKvhVpcprAIn5KkehQEh+47oHH2VGnExEh7dhNxXlg6GPAOIu6TxbVQxhebrJDvjl3020ooiWCMA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   unicorn-magic@0.4.0:
     resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
     engines: {node: '>=20'}
 
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
+  unplugin-dts@1.0.2:
+    resolution: {integrity: sha512-VbNiMD0LMl/t6nJueGtrCp79N7ZO1nquxj/FUybJDnKwZGsnW2wjdwBSzA3QEHujoxmxZIptsG43hL7LzXE96w==}
+    peerDependencies:
+      '@microsoft/api-extractor': '>=7'
+      '@rspack/core': ^1
+      '@vue/language-core': ~3.1.5
+      esbuild: '*'
+      rolldown: '*'
+      rollup: '>=3'
+      typescript: '>=4'
+      vite: '>=3'
+      webpack: ^4 || ^5
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@rspack/core':
+        optional: true
+      '@vue/language-core':
+        optional: true
+      esbuild:
+        optional: true
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+
   unplugin-utils@0.3.1:
     resolution: {integrity: sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==}
     engines: {node: '>=20.19.0'}
+
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
+    engines: {node: '>=18.12.0'}
 
   unplugin@3.0.0:
     resolution: {integrity: sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==}
@@ -1545,6 +2128,20 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vite-plugin-dts@5.0.2:
+    resolution: {integrity: sha512-lNeHS+dwGju6eRmNvZQt8Shwv9j3m98hbHse/lIbLq9q3yE2DcIOBBYQEVUF6tS0kOmv+VA9Z5FqmzFnGe4U8g==}
+    peerDependencies:
+      '@microsoft/api-extractor': '>=7'
+      rollup: '>=3'
+      vite: '>=3'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
 
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
@@ -1589,6 +2186,53 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  vue-component-type-helpers@3.3.3:
+    resolution: {integrity: sha512-x4nsFpy5Pe8fqPzp/5vkTPeTTDBpAx4WVtV47Ejt0+2FQrq4pRRsJs7JmYRqMFzTu/LW+pCWEjQ3YVCkPV7f9g==}
+
   vue-eslint-parser@10.4.1:
     resolution: {integrity: sha512-Gk6gRDj0n/fkRa3C3l0bBheoBckUq/Rs0F/TvMWIS6nzzx67amAViMe9CkNgsP2tXyQONvGiHQESHwFtZ3aYDA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1613,6 +2257,12 @@ packages:
       vite:
         optional: true
 
+  vue-tsc@3.3.3:
+    resolution: {integrity: sha512-SWUEG7YRUeDJHT7Xsuhf02elYX2gxPzzAII7OxDAh4KNOr4QHQ0Lls0YfnaO5GNd560CwVa2HTfdqmA5MqvRqQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
+
   vue@3.5.35:
     resolution: {integrity: sha512-cx89fnr+0kVGHiNFG6y6s0bdjypJRFNZn6x3WPstNdQR1bi1mbB7h4v5IBGTsPJU3nK1+0Iqj3Zf+hZWMieR4Q==}
     peerDependencies:
@@ -1624,6 +2274,10 @@ packages:
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
     hasBin: true
@@ -1633,9 +2287,34 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   write-file-atomic@7.0.1:
     resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
@@ -1704,6 +2383,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 8.0.0-rc.6
       '@babel/helper-validator-identifier': 8.0.0-rc.6
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@cacheable/memory@2.0.9':
     dependencies:
@@ -1816,6 +2497,15 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1847,6 +2537,41 @@ snapshots:
 
   '@mdi/font@7.4.47': {}
 
+  '@microsoft/api-extractor-model@7.33.8(@types/node@25.9.1)':
+    dependencies:
+      '@microsoft/tsdoc': 0.16.0
+      '@microsoft/tsdoc-config': 0.18.1
+      '@rushstack/node-core-library': 5.23.1(@types/node@25.9.1)
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@microsoft/api-extractor@7.58.7(@types/node@25.9.1)':
+    dependencies:
+      '@microsoft/api-extractor-model': 7.33.8(@types/node@25.9.1)
+      '@microsoft/tsdoc': 0.16.0
+      '@microsoft/tsdoc-config': 0.18.1
+      '@rushstack/node-core-library': 5.23.1(@types/node@25.9.1)
+      '@rushstack/rig-package': 0.7.3
+      '@rushstack/terminal': 0.24.0(@types/node@25.9.1)
+      '@rushstack/ts-command-line': 5.3.9(@types/node@25.9.1)
+      diff: 8.0.4
+      minimatch: 10.2.3
+      resolve: 1.22.12
+      semver: 7.7.4
+      source-map: 0.6.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@microsoft/tsdoc-config@0.18.1':
+    dependencies:
+      '@microsoft/tsdoc': 0.16.0
+      ajv: 8.18.0
+      jju: 1.4.0
+      resolve: 1.22.12
+
+  '@microsoft/tsdoc@0.16.0': {}
+
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -1865,6 +2590,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.16.0
+
+  '@one-ini/wasm@0.1.1': {}
 
   '@oxc-project/types@0.133.0': {}
 
@@ -1929,6 +2656,9 @@ snapshots:
       '@parcel/watcher-win32-x64': 2.5.6
     optional: true
 
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
 
@@ -1980,12 +2710,68 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@rollup/pluginutils@5.4.0':
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-walker: 2.0.2
+      picomatch: 4.0.4
+
+  '@rushstack/node-core-library@5.23.1(@types/node@25.9.1)':
+    dependencies:
+      ajv: 8.18.0
+      ajv-draft-04: 1.0.0(ajv@8.18.0)
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      fs-extra: 11.3.5
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.12
+      semver: 7.7.4
+    optionalDependencies:
+      '@types/node': 25.9.1
+
+  '@rushstack/problem-matcher@0.2.1(@types/node@25.9.1)':
+    optionalDependencies:
+      '@types/node': 25.9.1
+
+  '@rushstack/rig-package@0.7.3':
+    dependencies:
+      jju: 1.4.0
+      resolve: 1.22.12
+
+  '@rushstack/terminal@0.24.0(@types/node@25.9.1)':
+    dependencies:
+      '@rushstack/node-core-library': 5.23.1(@types/node@25.9.1)
+      '@rushstack/problem-matcher': 0.2.1(@types/node@25.9.1)
+      supports-color: 8.1.1
+    optionalDependencies:
+      '@types/node': 25.9.1
+
+  '@rushstack/ts-command-line@5.3.9(@types/node@25.9.1)':
+    dependencies:
+      '@rushstack/terminal': 0.24.0(@types/node@25.9.1)
+      '@types/argparse': 1.0.38
+      argparse: 1.0.10
+      string-argv: 0.3.2
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/argparse@1.0.38': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
 
@@ -1995,13 +2781,183 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@vitejs/plugin-vue@6.0.7(vite@8.0.16(sass@1.100.0)(yaml@2.9.0))(vue@3.5.35)':
+  '@types/node@25.9.1':
+    dependencies:
+      undici-types: 7.24.6
+
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.9.1
+
+  '@types/youtube@0.2.0': {}
+
+  '@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3))(eslint@10.4.1)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.60.1
+      '@typescript-eslint/type-utils': 8.60.1(eslint@10.4.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.60.1(eslint@10.4.1)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.60.1
+      eslint: 10.4.1
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.60.1
+      '@typescript-eslint/types': 8.60.1
+      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.60.1
+      debug: 4.4.3
+      eslint: 10.4.1
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.60.1(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.60.1(typescript@6.0.3)
+      '@typescript-eslint/types': 8.60.1
+      debug: 4.4.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.60.1':
+    dependencies:
+      '@typescript-eslint/types': 8.60.1
+      '@typescript-eslint/visitor-keys': 8.60.1
+
+  '@typescript-eslint/tsconfig-utils@8.60.1(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@typescript-eslint/type-utils@8.60.1(eslint@10.4.1)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.60.1
+      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.60.1(eslint@10.4.1)(typescript@6.0.3)
+      debug: 4.4.3
+      eslint: 10.4.1
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.60.1': {}
+
+  '@typescript-eslint/typescript-estree@8.60.1(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.60.1(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.60.1(typescript@6.0.3)
+      '@typescript-eslint/types': 8.60.1
+      '@typescript-eslint/visitor-keys': 8.60.1
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.1
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.60.1(eslint@10.4.1)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1)
+      '@typescript-eslint/scope-manager': 8.60.1
+      '@typescript-eslint/types': 8.60.1
+      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.3)
+      eslint: 10.4.1
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.60.1':
+    dependencies:
+      '@typescript-eslint/types': 8.60.1
+      eslint-visitor-keys: 5.0.1
+
+  '@vitejs/plugin-vue@6.0.7(vite@8.0.16(@types/node@25.9.1)(sass@1.100.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.16(sass@1.100.0)(yaml@2.9.0)
-      vue: 3.5.35
+      vite: 8.0.16(@types/node@25.9.1)(sass@1.100.0)(yaml@2.9.0)
+      vue: 3.5.35(typescript@6.0.3)
 
-  '@vue-macros/common@3.1.2(vue@3.5.35)':
+  '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.8
+      ast-v8-to-istanbul: 1.0.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.1
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(vite@8.0.16(@types/node@25.9.1)(sass@1.100.0)(yaml@2.9.0))
+
+  '@vitest/expect@4.1.8':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.1)(sass@1.100.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.16(@types/node@25.9.1)(sass@1.100.0)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.8':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.8':
+    dependencies:
+      '@vitest/utils': 4.1.8
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.8': {}
+
+  '@vitest/utils@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  '@volar/language-core@2.4.28':
+    dependencies:
+      '@volar/source-map': 2.4.28
+
+  '@volar/source-map@2.4.28': {}
+
+  '@volar/typescript@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
+  '@vue-macros/common@3.1.2(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@vue/compiler-sfc': 3.5.35
       ast-kit: 2.2.0
@@ -2009,7 +2965,7 @@ snapshots:
       magic-string-ast: 1.0.3
       unplugin-utils: 0.3.1
     optionalDependencies:
-      vue: 3.5.35
+      vue: 3.5.35(typescript@6.0.3)
 
   '@vue/compiler-core@3.5.35':
     dependencies:
@@ -2072,6 +3028,16 @@ snapshots:
 
   '@vue/devtools-shared@8.1.2': {}
 
+  '@vue/language-core@3.3.3':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      '@vue/compiler-dom': 3.5.35
+      '@vue/shared': 3.5.35
+      alien-signals: 3.2.1
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+      picomatch: 4.0.4
+
   '@vue/reactivity@3.5.35':
     dependencies:
       '@vue/shared': 3.5.35
@@ -2088,19 +3054,38 @@ snapshots:
       '@vue/shared': 3.5.35
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.35(vue@3.5.35)':
+  '@vue/server-renderer@3.5.35(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@vue/compiler-ssr': 3.5.35
       '@vue/shared': 3.5.35
-      vue: 3.5.35
+      vue: 3.5.35(typescript@6.0.3)
 
   '@vue/shared@3.5.35': {}
+
+  '@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.35)(@vue/server-renderer@3.5.35(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))':
+    dependencies:
+      '@vue/compiler-dom': 3.5.35
+      js-beautify: 1.15.4
+      vue: 3.5.35(typescript@6.0.3)
+      vue-component-type-helpers: 3.3.3
+    optionalDependencies:
+      '@vue/server-renderer': 3.5.35(vue@3.5.35(typescript@6.0.3))
+
+  abbrev@2.0.0: {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  ajv-draft-04@1.0.0(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
 
   ajv@6.15.0:
     dependencies:
@@ -2116,6 +3101,15 @@ snapshots:
       require-from-string: 2.0.2
       uri-js: 4.4.1
 
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  alien-signals@3.2.1: {}
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -2128,12 +3122,26 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@6.2.3: {}
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   argparse@2.0.1: {}
+
+  assertion-error@2.0.1: {}
 
   ast-kit@2.2.0:
     dependencies:
       '@babel/parser': 7.29.7
       pathe: 2.0.3
+
+  ast-v8-to-istanbul@1.0.3:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   ast-walker-scope@0.9.0:
     dependencies:
@@ -2143,11 +3151,17 @@ snapshots:
 
   astral-regex@2.0.0: {}
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   birpc@2.9.0: {}
 
   boolbase@1.0.0: {}
+
+  brace-expansion@2.1.1:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.6:
     dependencies:
@@ -2166,6 +3180,8 @@ snapshots:
       qified: 0.10.1
 
   callsites@3.1.0: {}
+
+  chai@6.2.2: {}
 
   chalk@2.4.2:
     dependencies:
@@ -2191,20 +3207,33 @@ snapshots:
 
   colord@2.9.3: {}
 
+  commander@10.0.1: {}
+
+  compare-versions@6.1.1: {}
+
   confbox@0.1.8: {}
 
   confbox@0.2.4: {}
+
+  config-chain@1.1.13:
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
+
+  convert-source-map@2.0.0: {}
 
   copy-anything@4.0.5:
     dependencies:
       is-what: 5.5.0
 
-  cosmiconfig@9.0.1:
+  cosmiconfig@9.0.1(typescript@6.0.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 6.0.3
 
   cross-spawn@7.0.6:
     dependencies:
@@ -2235,6 +3264,8 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
+  diff@8.0.4: {}
+
   dom-serializer@2.0.0:
     dependencies:
       domelementtype: 2.3.0
@@ -2253,7 +3284,18 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
+  eastasianwidth@0.2.0: {}
+
+  editorconfig@1.0.7:
+    dependencies:
+      '@one-ini/wasm': 0.1.1
+      commander: 10.0.1
+      minimatch: 9.0.9
+      semver: 7.8.1
+
   emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   entities@4.5.0: {}
 
@@ -2265,11 +3307,15 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
+  es-errors@1.3.0: {}
+
+  es-module-lexer@2.1.0: {}
+
   escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-vue@10.9.2(eslint@10.4.1)(vue-eslint-parser@10.4.1(eslint@10.4.1)):
+  eslint-plugin-vue@10.9.2(@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3))(eslint@10.4.1)(vue-eslint-parser@10.4.1(eslint@10.4.1)):
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@10.4.1)
       eslint: 10.4.1
@@ -2279,6 +3325,8 @@ snapshots:
       semver: 7.8.1
       vue-eslint-parser: 10.4.1(eslint@10.4.1)
       xml-name-validator: 4.0.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1)(typescript@6.0.3)
 
   eslint-scope@9.1.2:
     dependencies:
@@ -2344,7 +3392,13 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   exsolve@1.0.8: {}
 
@@ -2361,6 +3415,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-uri@3.1.2: {}
 
   fastest-levenshtein@1.0.16: {}
 
@@ -2404,8 +3460,21 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  fs-extra@11.3.5:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
 
   get-east-asian-width@1.6.0: {}
 
@@ -2416,6 +3485,15 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
 
   global-modules@2.0.0:
     dependencies:
@@ -2440,13 +3518,33 @@ snapshots:
 
   globjoin@0.1.4: {}
 
+  graceful-fs@4.2.11: {}
+
+  happy-dom@20.9.0:
+    dependencies:
+      '@types/node': 25.9.1
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   has-flag@3.0.0: {}
+
+  has-flag@4.0.0: {}
 
   has-flag@5.0.1: {}
 
   hashery@1.5.1:
     dependencies:
       hookified: 1.15.1
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
 
   highlight.js@11.11.1: {}
 
@@ -2455,6 +3553,8 @@ snapshots:
   hookified@1.15.1: {}
 
   hookified@2.2.0: {}
+
+  html-escaper@2.0.2: {}
 
   html-tags@5.1.0: {}
 
@@ -2476,6 +3576,8 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-lazy@4.0.0: {}
+
   import-meta-resolve@4.2.0: {}
 
   imurmurhash@0.1.4: {}
@@ -2483,6 +3585,10 @@ snapshots:
   ini@1.3.8: {}
 
   is-arrayish@0.2.1: {}
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.4
 
   is-extglob@2.1.1: {}
 
@@ -2501,6 +3607,39 @@ snapshots:
   is-what@5.5.0: {}
 
   isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  jju@1.4.0: {}
+
+  js-beautify@1.15.4:
+    dependencies:
+      config-chain: 1.1.13
+      editorconfig: 1.0.7
+      glob: 10.5.0
+      js-cookie: 3.0.8
+      nopt: 7.2.1
+
+  js-cookie@3.0.8: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -2524,6 +3663,12 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -2535,6 +3680,8 @@ snapshots:
   kind-of@6.0.3: {}
 
   known-css-properties@0.37.0: {}
+
+  kolorist@1.8.0: {}
 
   levn@0.4.1:
     dependencies:
@@ -2604,6 +3751,8 @@ snapshots:
 
   lodash.truncate@4.4.2: {}
 
+  lru-cache@10.4.3: {}
+
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
@@ -2615,6 +3764,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.1
 
   mathml-tag-names@4.0.0: {}
 
@@ -2629,9 +3788,19 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  minimatch@10.2.3:
+    dependencies:
+      brace-expansion: 5.0.6
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.1
+
+  minipass@7.1.3: {}
 
   mitt@3.0.1: {}
 
@@ -2655,11 +3824,17 @@ snapshots:
   node-addon-api@7.1.1:
     optional: true
 
+  nopt@7.2.1:
+    dependencies:
+      abbrev: 2.0.0
+
   normalize-path@3.0.0: {}
 
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
+
+  obug@2.1.1: {}
 
   optionator@0.9.3:
     dependencies:
@@ -2678,6 +3853,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  package-json-from-dist@1.0.1: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -2689,9 +3866,18 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  path-browserify@1.0.1: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   pathe@2.0.3: {}
 
@@ -2705,10 +3891,12 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  pinia@3.0.4(vue@3.5.35):
+  pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)):
     dependencies:
       '@vue/devtools-api': 7.7.9
-      vue: 3.5.35
+      vue: 3.5.35(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
 
   pkg-types@1.3.1:
     dependencies:
@@ -2760,6 +3948,8 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  proto-list@1.2.4: {}
+
   punycode@2.3.1: {}
 
   qified@0.10.1:
@@ -2775,6 +3965,13 @@ snapshots:
   require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.0.4: {}
 
@@ -2819,6 +4016,8 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
+  semver@7.7.4: {}
+
   semver@7.8.1: {}
 
   shebang-command@2.0.0:
@@ -2826,6 +4025,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
 
@@ -2841,13 +4042,29 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map@0.6.1: {}
+
   speakingurl@14.0.1: {}
+
+  sprintf-js@1.0.3: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
+
+  string-argv@0.3.2: {}
 
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
 
   string-width@8.2.1:
     dependencies:
@@ -2862,50 +4079,50 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
-  stylelint-config-html@1.1.0(postcss-html@1.8.1)(stylelint@17.12.0):
+  stylelint-config-html@1.1.0(postcss-html@1.8.1)(stylelint@17.12.0(typescript@6.0.3)):
     dependencies:
       postcss-html: 1.8.1
-      stylelint: 17.12.0
+      stylelint: 17.12.0(typescript@6.0.3)
 
-  stylelint-config-recommended-scss@17.0.1(postcss@8.5.15)(stylelint@17.12.0):
+  stylelint-config-recommended-scss@17.0.1(postcss@8.5.15)(stylelint@17.12.0(typescript@6.0.3)):
     dependencies:
       postcss-scss: 4.0.9(postcss@8.5.15)
-      stylelint: 17.12.0
-      stylelint-config-recommended: 18.0.0(stylelint@17.12.0)
-      stylelint-scss: 7.2.0(stylelint@17.12.0)
+      stylelint: 17.12.0(typescript@6.0.3)
+      stylelint-config-recommended: 18.0.0(stylelint@17.12.0(typescript@6.0.3))
+      stylelint-scss: 7.2.0(stylelint@17.12.0(typescript@6.0.3))
     optionalDependencies:
       postcss: 8.5.15
 
-  stylelint-config-recommended-vue@1.6.1(postcss-html@1.8.1)(stylelint@17.12.0):
+  stylelint-config-recommended-vue@1.6.1(postcss-html@1.8.1)(stylelint@17.12.0(typescript@6.0.3)):
     dependencies:
       postcss-html: 1.8.1
       semver: 7.5.4
-      stylelint: 17.12.0
-      stylelint-config-html: 1.1.0(postcss-html@1.8.1)(stylelint@17.12.0)
-      stylelint-config-recommended: 14.0.0(stylelint@17.12.0)
+      stylelint: 17.12.0(typescript@6.0.3)
+      stylelint-config-html: 1.1.0(postcss-html@1.8.1)(stylelint@17.12.0(typescript@6.0.3))
+      stylelint-config-recommended: 14.0.0(stylelint@17.12.0(typescript@6.0.3))
 
-  stylelint-config-recommended@14.0.0(stylelint@17.12.0):
+  stylelint-config-recommended@14.0.0(stylelint@17.12.0(typescript@6.0.3)):
     dependencies:
-      stylelint: 17.12.0
+      stylelint: 17.12.0(typescript@6.0.3)
 
-  stylelint-config-recommended@18.0.0(stylelint@17.12.0):
+  stylelint-config-recommended@18.0.0(stylelint@17.12.0(typescript@6.0.3)):
     dependencies:
-      stylelint: 17.12.0
+      stylelint: 17.12.0(typescript@6.0.3)
 
-  stylelint-config-standard-scss@17.0.0(postcss@8.5.15)(stylelint@17.12.0):
+  stylelint-config-standard-scss@17.0.0(postcss@8.5.15)(stylelint@17.12.0(typescript@6.0.3)):
     dependencies:
-      stylelint: 17.12.0
-      stylelint-config-recommended-scss: 17.0.1(postcss@8.5.15)(stylelint@17.12.0)
-      stylelint-config-standard: 40.0.0(stylelint@17.12.0)
+      stylelint: 17.12.0(typescript@6.0.3)
+      stylelint-config-recommended-scss: 17.0.1(postcss@8.5.15)(stylelint@17.12.0(typescript@6.0.3))
+      stylelint-config-standard: 40.0.0(stylelint@17.12.0(typescript@6.0.3))
     optionalDependencies:
       postcss: 8.5.15
 
-  stylelint-config-standard@40.0.0(stylelint@17.12.0):
+  stylelint-config-standard@40.0.0(stylelint@17.12.0(typescript@6.0.3)):
     dependencies:
-      stylelint: 17.12.0
-      stylelint-config-recommended: 18.0.0(stylelint@17.12.0)
+      stylelint: 17.12.0(typescript@6.0.3)
+      stylelint-config-recommended: 18.0.0(stylelint@17.12.0(typescript@6.0.3))
 
-  stylelint-scss@7.2.0(stylelint@17.12.0):
+  stylelint-scss@7.2.0(stylelint@17.12.0(typescript@6.0.3)):
     dependencies:
       '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
@@ -2918,9 +4135,9 @@ snapshots:
       postcss-resolve-nested-selector: 0.1.6
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
-      stylelint: 17.12.0
+      stylelint: 17.12.0(typescript@6.0.3)
 
-  stylelint@17.12.0:
+  stylelint@17.12.0(typescript@6.0.3):
     dependencies:
       '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
@@ -2930,7 +4147,7 @@ snapshots:
       '@csstools/selector-resolve-nested': 4.0.0(postcss-selector-parser@7.1.1)
       '@csstools/selector-specificity': 6.0.0(postcss-selector-parser@7.1.1)
       colord: 2.9.3
-      cosmiconfig: 9.0.1
+      cosmiconfig: 9.0.1(typescript@6.0.3)
       css-functions-list: 3.3.3
       css-tree: 3.2.1
       debug: 4.4.3
@@ -2971,10 +4188,20 @@ snapshots:
     dependencies:
       has-flag: 3.0.0
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
   supports-hyperlinks@4.4.0:
     dependencies:
       has-flag: 5.0.1
       supports-color: 10.2.2
+
+  supports-preserve-symlinks-flag@1.0.0: {}
 
   svg-tags@1.0.0: {}
 
@@ -2986,14 +4213,24 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyrainbow@3.1.0: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  ts-api-utils@2.5.0(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
 
   tslib@2.8.1:
     optional: true
@@ -3002,14 +4239,58 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  typescript-eslint@8.60.1(eslint@10.4.1)(typescript@6.0.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3))(eslint@10.4.1)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.60.1(eslint@10.4.1)(typescript@6.0.3)
+      eslint: 10.4.1
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript@5.9.3: {}
+
+  typescript@6.0.3: {}
+
   ufo@1.6.4: {}
 
+  undici-types@7.24.6: {}
+
   unicorn-magic@0.4.0: {}
+
+  universalify@2.0.1: {}
+
+  unplugin-dts@1.0.2(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(rolldown@1.0.3)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(sass@1.100.0)(yaml@2.9.0)):
+    dependencies:
+      '@rollup/pluginutils': 5.4.0
+      '@volar/typescript': 2.4.28
+      compare-versions: 6.1.1
+      debug: 4.4.3
+      kolorist: 1.8.0
+      local-pkg: 1.2.1
+      magic-string: 0.30.21
+      typescript: 6.0.3
+      unplugin: 2.3.11
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.58.7(@types/node@25.9.1)
+      rolldown: 1.0.3
+      vite: 8.0.16(@types/node@25.9.1)(sass@1.100.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
 
   unplugin-utils@0.3.1:
     dependencies:
       pathe: 2.0.3
       picomatch: 4.0.4
+
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.16.0
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
 
   unplugin@3.0.0:
     dependencies:
@@ -3023,7 +4304,22 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite@8.0.16(sass@1.100.0)(yaml@2.9.0):
+  vite-plugin-dts@5.0.2(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(rolldown@1.0.3)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(sass@1.100.0)(yaml@2.9.0)):
+    dependencies:
+      unplugin-dts: 1.0.2(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(rolldown@1.0.3)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(sass@1.100.0)(yaml@2.9.0))
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.58.7(@types/node@25.9.1)
+      vite: 8.0.16(@types/node@25.9.1)(sass@1.100.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - '@vue/language-core'
+      - esbuild
+      - rolldown
+      - supports-color
+      - typescript
+      - webpack
+
+  vite@8.0.16(@types/node@25.9.1)(sass@1.100.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -3031,9 +4327,43 @@ snapshots:
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:
+      '@types/node': 25.9.1
       fsevents: 2.3.3
       sass: 1.100.0
       yaml: 2.9.0
+
+  vitest@4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(vite@8.0.16(@types/node@25.9.1)(sass@1.100.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.1)(sass@1.100.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@25.9.1)(sass@1.100.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.1
+      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
+      happy-dom: 20.9.0
+    transitivePeerDependencies:
+      - msw
+
+  vscode-uri@3.1.0: {}
+
+  vue-component-type-helpers@3.3.3: {}
 
   vue-eslint-parser@10.4.1(eslint@10.4.1):
     dependencies:
@@ -3047,10 +4377,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-router@5.1.0(@vue/compiler-sfc@3.5.35)(pinia@3.0.4(vue@3.5.35))(vite@8.0.16(sass@1.100.0)(yaml@2.9.0))(vue@3.5.35):
+  vue-router@5.1.0(@vue/compiler-sfc@3.5.35)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(vite@8.0.16(@types/node@25.9.1)(sass@1.100.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.6
-      '@vue-macros/common': 3.1.2(vue@3.5.35)
+      '@vue-macros/common': 3.1.2(vue@3.5.35(typescript@6.0.3))
       '@vue/devtools-api': 8.1.2
       ast-walker-scope: 0.9.0
       chokidar: 5.0.0
@@ -3065,22 +4395,32 @@ snapshots:
       tinyglobby: 0.2.17
       unplugin: 3.0.0
       unplugin-utils: 0.3.1
-      vue: 3.5.35
+      vue: 3.5.35(typescript@6.0.3)
       yaml: 2.9.0
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.35
-      pinia: 3.0.4(vue@3.5.35)
-      vite: 8.0.16(sass@1.100.0)(yaml@2.9.0)
+      pinia: 3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3))
+      vite: 8.0.16(@types/node@25.9.1)(sass@1.100.0)(yaml@2.9.0)
 
-  vue@3.5.35:
+  vue-tsc@3.3.3(typescript@6.0.3):
+    dependencies:
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 3.3.3
+      typescript: 6.0.3
+
+  vue@3.5.35(typescript@6.0.3):
     dependencies:
       '@vue/compiler-dom': 3.5.35
       '@vue/compiler-sfc': 3.5.35
       '@vue/runtime-dom': 3.5.35
-      '@vue/server-renderer': 3.5.35(vue@3.5.35)
+      '@vue/server-renderer': 3.5.35(vue@3.5.35(typescript@6.0.3))
       '@vue/shared': 3.5.35
+    optionalDependencies:
+      typescript: 6.0.3
 
   webpack-virtual-modules@0.6.2: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   which@1.3.1:
     dependencies:
@@ -3090,9 +4430,28 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
+
   write-file-atomic@7.0.1:
     dependencies:
       signal-exit: 4.1.0
+
+  ws@8.21.0: {}
 
   xml-name-validator@4.0.0: {}
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -46,7 +46,7 @@ watch(isDark, (val) => {
 	--vue-color: #42b883;
 }
 
-body:not([theme-dark]) {
+body:not(.theme--dark) {
 	/* stylelint-disable-next-line */
 	@include meta.load-css("highlight.js/styles/github.css");
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -46,6 +46,15 @@ watch(isDark, (val) => {
 	--vue-color: #42b883;
 }
 
+/* Shared design tokens (light defaults; overridden under .theme--dark) */
+body {
+	--surface: #fff;
+	--surface-2: #f6f7f9;
+	--border: #e4e6ea;
+	--muted: #6b7280;
+	--code-bg: #f3f4f6;
+}
+
 body:not(.theme--dark) {
 	/* stylelint-disable-next-line */
 	@include meta.load-css("highlight.js/styles/github.css");
@@ -55,6 +64,12 @@ body:not(.theme--dark) {
 body.theme--dark {
 	/* stylelint-disable-next-line */
 	@include meta.load-css("highlight.js/styles/github-dark.css");
+
+	--surface: #242424;
+	--surface-2: #1c1c1c;
+	--border: #383838;
+	--muted: #9ca3af;
+	--code-bg: #2a2a2a;
 
 	background-color: #1a1a1a;
 	color: #fff;

--- a/src/components/AppBar.vue
+++ b/src/components/AppBar.vue
@@ -59,7 +59,6 @@ const {isDark, toggleDark} = useAppStore()
 
 	&--title {
 		font-size: 1rem;
-		font-size: 1rem;
 		font-weight: 500;
 		margin-left: .5rem;
 	}

--- a/src/components/AppBar.vue
+++ b/src/components/AppBar.vue
@@ -54,11 +54,12 @@ const {isDark, toggleDark} = useAppStore()
 
 	.mdi-youtube {
 		color: var(--vue-color);
-		font-size: 3rem;
+		font-size: 2rem;
 	}
 
 	&--title {
-		font-size: clamp(1rem , 1.5vw, 1.5rem);
+		font-size: 1rem;
+		font-size: 1rem;
 		font-weight: 500;
 		margin-left: .5rem;
 	}
@@ -76,8 +77,7 @@ const {isDark, toggleDark} = useAppStore()
 		}
 
 		& > .link {
-			font-size: clamp(.875rem , 1.5vw, 1rem);
-			font-weight: 500;
+			font-size: .875rem;
 			cursor: pointer;
 			color: inherit;
 			text-decoration: none;

--- a/src/components/AppBar.vue
+++ b/src/components/AppBar.vue
@@ -1,31 +1,43 @@
 <template>
 	<header class="app-bar">
-		<a class="app-bar--head" href="/vue3-ytframe/#/">
-			<div class="mdi mdi-youtube" />
+		<RouterLink class="app-bar--head" :to="{name: 'Home'}">
+			<div class="mdi mdi-youtube" aria-hidden="true" />
 			<div class="app-bar--title">Vue3 Ytframe</div>
-		</a>
-		<div class="app-bar--actions">
-			<div class="link" @click="push({name: 'Home'})">Home</div>
-			<div class="link" @click="push({name: 'Docs'})">Docs</div>
-			<div class="link" @click="push({name: 'Playground'})">Playground</div>
-			<div class="link" @click="push({name: 'About'})">About</div>
+		</RouterLink>
+		<nav class="app-bar--actions" aria-label="Primary">
+			<RouterLink class="link" :to="{name: 'Home'}">Home</RouterLink>
+			<RouterLink class="link" :to="{name: 'Docs'}">Docs</RouterLink>
+			<RouterLink class="link" :to="{name: 'Playground'}">Playground</RouterLink>
+			<RouterLink class="link" :to="{name: 'About'}">About</RouterLink>
 			<div class="separator" />
-			<div class="theme-select" @click="toggleDark()" title="Toggle Theme">
-				<div v-if="isDark" class="mdi mdi-weather-night"/>
-				<div v-else class="mdi mdi-weather-sunny"/>
-			</div>
-			<a class="icon-link" href="https://github.com/kiranparajuli589/vue3-ytframe" title="GitHub" target="_blank">
-				<div class="mdi mdi-github" />
+			<button
+				type="button"
+				class="theme-select"
+				:aria-pressed="isDark"
+				:title="isDark ? 'Switch to light theme' : 'Switch to dark theme'"
+				aria-label="Toggle theme"
+				@click="toggleDark()"
+			>
+				<div v-if="isDark" class="mdi mdi-weather-night" aria-hidden="true" />
+				<div v-else class="mdi mdi-weather-sunny" aria-hidden="true" />
+			</button>
+			<a
+				class="icon-link"
+				href="https://github.com/kiranparajuli589/vue3-ytframe"
+				title="GitHub"
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				<div class="mdi mdi-github" aria-hidden="true" />
 			</a>
-		</div>
+		</nav>
 	</header>
 </template>
 <script setup>
 import useAppStore from "../composables/useAppStore.js"
-import {useRouter} from "vue-router"
+import {RouterLink} from "vue-router"
 
 const {isDark, toggleDark} = useAppStore()
-const {push} = useRouter()
 </script>
 <style lang="scss">
 .app-bar {
@@ -67,6 +79,8 @@ const {push} = useRouter()
 			font-size: clamp(.875rem , 1.5vw, 1rem);
 			font-weight: 500;
 			cursor: pointer;
+			color: inherit;
+			text-decoration: none;
 
 			&:hover {
 				color: #34ab38;
@@ -91,6 +105,10 @@ const {push} = useRouter()
 		.theme-select {
 			position: relative;
 			outline: 1px solid grey;
+			border: 0;
+			padding: 0;
+			background: transparent;
+			color: inherit;
 			border-radius: 24px;
 			width: 40px;
 			height: 22px;

--- a/src/components/DocsNav.vue
+++ b/src/components/DocsNav.vue
@@ -2,16 +2,13 @@
 	<aside class="docs-nav">
 		<h2 class="docs-nav--title">Docs</h2>
 		<ul class="docs-nav--list">
-			<li v-for="(doc, n) in docItems" :key="n"
-				class="docs-nav--item"
-			>
-				<header>{{doc.title}}</header>
+			<li v-for="(doc, n) in docItems" :key="n" class="docs-nav--group">
+				<header class="docs-nav--group-title">{{ doc.title }}</header>
 				<ul class="docs-nav--inner-list">
-					<li v-for="(item, index) in doc.items" :key="index"
-						class="docs-nav--inner-item"
-						@click="scrollToItem(item.title)"
-					>
-						<header>{{item.title}}</header>
+					<li v-for="(item, index) in doc.items" :key="index">
+						<button type="button" class="docs-nav--link" @click="scrollToItem(item.title)">
+							{{ item.title }}
+						</button>
 					</li>
 				</ul>
 			</li>
@@ -60,44 +57,69 @@ const scrollToItem = (title) => {
 <style lang="scss">
 .docs-nav {
 	position: absolute;
-	width: 200px;
-	padding: 1rem;
+	width: 220px;
+	padding: 1.5rem 1rem;
 	height: 100%;
-	border-right: 1px solid grey;
+	overflow-y: auto;
+	border-right: 1px solid var(--border);
+	background: var(--surface-2);
 
 	@media only screen and (width <= 600px) {
 		display: none;
 	}
 
 	&--title {
-		margin-bottom: 2rem;
+		font-size: 1.4rem;
+		font-weight: 800;
+		letter-spacing: -.5px;
+		margin-bottom: 1.5rem;
 	}
 
 	&--list {
 		list-style: none;
 	}
 
-	&--item {
+	&--group {
 		margin-bottom: 1.5rem;
 	}
 
-	&--item > header {
-		font-size: 1.2rem;
-		font-weight: 600;
-		margin-bottom: 1em;
-		border-bottom: 1px solid grey;
-		width: fit-content;
-		padding-inline: .2rem;
+	&--group-title {
+		font-size: .75rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: .06em;
+		color: var(--muted);
+		margin-bottom: .5rem;
+		padding-inline: .6rem;
 	}
 
 	&--inner-list {
 		list-style: none;
-		padding-left: .2rem;
+		display: flex;
+		flex-direction: column;
+		gap: .15rem;
 	}
 
-	&--inner-item {
-		margin-bottom: 0.7rem;
+	&--link {
+		display: block;
+		width: 100%;
+		text-align: left;
+		font: inherit;
+		font-size: .9rem;
+		color: inherit;
+		padding: .4rem .6rem;
+		border: 0;
+		border-left: 2px solid transparent;
+		border-radius: 6px;
+		background: transparent;
 		cursor: pointer;
+		transition: background .15s, color .15s, border-color .15s;
+
+		&:hover {
+			background: var(--surface);
+			color: var(--vue-color);
+			border-left-color: var(--vue-color);
+		}
 	}
 }
 </style>

--- a/src/components/TheFooter.vue
+++ b/src/components/TheFooter.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="footer">
 		<div>Released under the <span class="bold">GPL-3 License</span></div>
-		<div>Copyright <span class="mdi mdi-copyright"/> 2022-2023 Kiran Parajuli</div>
+		<div>Copyright <span class="mdi mdi-copyright"/> 2022-2026 Kiran Parajuli</div>
 	</div>
 </template>
 <style lang="scss">

--- a/src/helper.js
+++ b/src/helper.js
@@ -77,7 +77,7 @@ export const ComponentProps = {
 			"playerVars",
 			"Object",
 			getCode("{}"),
-			"The playerVars object to be passed to the YouTube Iframe API. (Ref: <a href=\"https://developers.google.com/youtube/player_parameters\" target=\"_blank\">Player Parameters</a>)"
+			"The playerVars object to be passed to the YouTube Iframe API. (Ref: <a href=\"https://developers.google.com/youtube/player_parameters\" target=\"_blank\" rel=\"noopener noreferrer\">Player Parameters</a>)"
 		], {
 			prop: "height",
 			type: "String, Number",

--- a/src/views/AboutPage.vue
+++ b/src/views/AboutPage.vue
@@ -1,40 +1,174 @@
 <template>
 	<div class="about">
-		<h2>About Vue3-Ytframe</h2>
-		<hr>
-		<div>Name: <span>{{pkg.name}}</span></div>
-		<div>Version: <span>{{pkg.version}}</span></div>
-		<div>Description: <span>{{pkg.description}}</span></div>
-		<div>Homepage: <span><a :href="pkg.homepage" target="_blank" rel="noopener noreferrer">{{pkg.homepage}}</a></span></div>
-		<div>Repository: <span><a :href="pkg.repository.url" target="_blank" rel="noopener noreferrer">{{pkg.repository.url}}</a></span></div>
-		<div>Issues: <span><a :href="pkg.bugs.url" target="_blank" rel="noopener noreferrer">{{pkg.bugs.url}}</a></span></div>
-		<div>Author: <span>{{pkg.author}}</span></div>
-		<div>License: <span>{{pkg.license}}</span></div>
+		<section class="about__card">
+			<header class="about__head">
+				<img class="about__logo" :src="logo" alt="vue3-ytframe logo">
+				<div class="about__heading">
+					<h2 class="about__name">{{ pkg.name }}</h2>
+					<p class="about__desc">{{ pkg.description }}</p>
+				</div>
+				<span class="about__version">v{{ pkg.version }}</span>
+			</header>
+
+			<dl class="about__grid">
+				<div class="about__row">
+					<dt>Author</dt>
+					<dd>{{ pkg.author }}</dd>
+				</div>
+				<div class="about__row">
+					<dt>License</dt>
+					<dd>{{ pkg.license }}</dd>
+				</div>
+				<div class="about__row">
+					<dt>Homepage</dt>
+					<dd><a :href="pkg.homepage" target="_blank" rel="noopener noreferrer">{{ pkg.homepage }}</a></dd>
+				</div>
+				<div class="about__row">
+					<dt>Repository</dt>
+					<dd><a :href="pkg.repository.url" target="_blank" rel="noopener noreferrer">{{ pkg.repository.url }}</a></dd>
+				</div>
+				<div class="about__row">
+					<dt>Issues</dt>
+					<dd><a :href="pkg.bugs.url" target="_blank" rel="noopener noreferrer">{{ pkg.bugs.url }}</a></dd>
+				</div>
+			</dl>
+
+			<div class="about__links">
+				<a class="about__btn" :href="pkg.repository.url" target="_blank" rel="noopener noreferrer">
+					<span class="mdi mdi-github" aria-hidden="true" /> GitHub
+				</a>
+				<a class="about__btn" href="https://www.npmjs.com/package/vue3-ytframe" target="_blank" rel="noopener noreferrer">
+					<span class="mdi mdi-npm" aria-hidden="true" /> npm
+				</a>
+			</div>
+		</section>
 	</div>
 </template>
 <script setup>
 import pkg from "../../package.json"
+import logo from "../assets/youtube.svg"
 </script>
 <style lang="scss">
 .about {
-	max-width: 600px;
+	max-width: 720px;
 	margin: 0 auto;
+	padding: 3rem 1rem 6rem;
 
-	h2 {
-		margin-top: 4rem;
-		margin-bottom: 1rem;
+	&__card {
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: 16px;
+		padding: 1.75rem;
+		box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
 	}
 
-	hr {
-		margin-bottom: 2rem;
+	&__head {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+		flex-wrap: wrap;
+		padding-bottom: 1.5rem;
+		margin-bottom: 1.5rem;
+		border-bottom: 1px solid var(--border);
 	}
 
-	div {
-		margin-bottom: .5rem;
+	&__logo {
+		width: 56px;
+		height: 56px;
+	}
 
-		span {
-			font-weight: 500;
+	&__heading {
+		flex: 1;
+		min-width: 200px;
+	}
+
+	&__name {
+		font-size: clamp(1.4rem, 3vw, 2rem);
+		font-weight: 800;
+		letter-spacing: -.5px;
+	}
+
+	&__desc {
+		margin-top: .25rem;
+		color: var(--muted);
+	}
+
+	&__version {
+		font-weight: 700;
+		font-size: .85rem;
+		color: var(--vue-color);
+		background: rgb(66 184 131 / 12%);
+		border: 1px solid rgb(66 184 131 / 30%);
+		padding: .25rem .7rem;
+		border-radius: 999px;
+		white-space: nowrap;
+	}
+
+	&__grid {
+		display: grid;
+		gap: .25rem;
+	}
+
+	&__row {
+		display: grid;
+		grid-template-columns: 130px 1fr;
+		gap: 1rem;
+		align-items: baseline;
+		padding: .6rem .25rem;
+		border-radius: 8px;
+
+		&:hover {
+			background: var(--surface-2);
 		}
+
+		dt {
+			font-weight: 600;
+			color: var(--muted);
+		}
+
+		dd {
+			font-weight: 500;
+			overflow-wrap: anywhere;
+		}
+
+		@media only screen and (width <= 480px) {
+			grid-template-columns: 1fr;
+			gap: .15rem;
+		}
+	}
+
+	&__links {
+		display: flex;
+		flex-wrap: wrap;
+		gap: .75rem;
+		margin-top: 1.75rem;
+	}
+
+	&__btn {
+		display: inline-flex;
+		align-items: center;
+		gap: .45rem;
+		font-weight: 600;
+		text-decoration: none;
+		color: inherit;
+		padding: .5rem 1rem;
+		border: 1px solid var(--border);
+		border-radius: 10px;
+		background: var(--surface-2);
+		transition: border-color .15s, color .15s;
+
+		&:hover {
+			border-color: var(--vue-color);
+			color: var(--vue-color);
+		}
+
+		.mdi {
+			font-size: 1.2rem;
+		}
+	}
+
+	a {
+		color: var(--vue-color);
 	}
 }
 </style>

--- a/src/views/AboutPage.vue
+++ b/src/views/AboutPage.vue
@@ -5,9 +5,9 @@
 		<div>Name: <span>{{pkg.name}}</span></div>
 		<div>Version: <span>{{pkg.version}}</span></div>
 		<div>Description: <span>{{pkg.description}}</span></div>
-		<div>Homepage: <span><a :href="pkg.homepage" target="_blank">{{pkg.homepage}}</a></span></div>
-		<div>Repository: <span><a :href="pkg.repository.url" target="_blank">{{pkg.repository.url}}</a></span></div>
-		<div>Issues: <span><a :href="pkg.bugs.url" target="_blank">{{pkg.bugs.url}}</a></span></div>
+		<div>Homepage: <span><a :href="pkg.homepage" target="_blank" rel="noopener noreferrer">{{pkg.homepage}}</a></span></div>
+		<div>Repository: <span><a :href="pkg.repository.url" target="_blank" rel="noopener noreferrer">{{pkg.repository.url}}</a></span></div>
+		<div>Issues: <span><a :href="pkg.bugs.url" target="_blank" rel="noopener noreferrer">{{pkg.bugs.url}}</a></span></div>
 		<div>Author: <span>{{pkg.author}}</span></div>
 		<div>License: <span>{{pkg.license}}</span></div>
 	</div>

--- a/src/views/DocsPage.vue
+++ b/src/views/DocsPage.vue
@@ -38,7 +38,7 @@
 </template>
 <script setup>
 import DocsNav from "../components/DocsNav.vue"
-import { onMounted, ref, watch } from "vue"
+import { nextTick, onMounted, onUnmounted, ref, watch } from "vue"
 import hljs from "highlight.js"
 import { useRouter } from "vue-router"
 import {
@@ -54,47 +54,39 @@ import VueYtframe from "../../lib/VueYtframe.vue"
 const appBarHeight = ref(0)
 const footerHeight = ref(0)
 
-onMounted(() => {
-	waitTillAppBarAndFooterLoads()
-		.then(() => {
-			handleResize()
-			window.addEventListener("resize", handleResize)
-			initializeCodeCopy()
-			initializeHeaderRefs()
-			hljs.highlightAll()
-			scrollToHeadingIfRefExists()
-		})
+onMounted(async () => {
+	// The app bar and footer live in App.vue and are already mounted by now;
+	// nextTick guarantees this view's own DOM is painted before we measure it.
+	await nextTick()
+	handleResize()
+	window.addEventListener("resize", handleResize)
+	initializeCodeCopy()
+	initializeHeaderRefs()
+	hljs.highlightAll()
+	scrollToHeadingIfRefExists()
+})
+
+onUnmounted(() => {
+	window.removeEventListener("resize", handleResize)
 })
 
 function handleResize() {
-	appBarHeight.value = `${document.querySelector(".app-bar").offsetHeight.toString()}px`
-	footerHeight.value = `${document.querySelector(".footer").offsetHeight.toString()}px`
-}
-
-function waitTillAppBarAndFooterLoads() {
-	return new Promise((resolve) => {
-		let appBar = document.querySelector(".app-bar")
-		let footer = document.querySelector(".footer")
-		if (appBar && footer) {
-			resolve()
-		} else {
-			setTimeout(() => {
-				waitTillAppBarAndFooterLoads()
-					.then(() => {
-						resolve()
-					})
-			}, 100)
-		}
-	})
+	const appBar = document.querySelector(".app-bar")
+	const footer = document.querySelector(".footer")
+	if (appBar) appBarHeight.value = `${appBar.offsetHeight}px`
+	if (footer) footerHeight.value = `${footer.offsetHeight}px`
 }
 
 const initializeCodeCopy = () => {
-	const codeBlocks = document.querySelectorAll("pre code")
-	codeBlocks.forEach((codeBlock) => {
+	document.querySelectorAll("pre code").forEach((codeBlock) => {
+		const pre = codeBlock.parentNode
+		if (!pre || pre.querySelector(".copy-button")) return // idempotent
 		const copyButton = document.createElement("button")
+		copyButton.type = "button"
 		copyButton.classList.add("copy-button")
-		copyButton.innerHTML = "<span class=\"mdi mdi-content-copy\" />"
-		codeBlock.parentNode.appendChild(copyButton)
+		copyButton.setAttribute("aria-label", "Copy code to clipboard")
+		copyButton.innerHTML = "<span class=\"mdi mdi-content-copy\" aria-hidden=\"true\" />"
+		pre.appendChild(copyButton)
 		copyButton.addEventListener("click", () => {
 			navigator.clipboard.writeText(codeBlock.innerText)
 		})
@@ -102,11 +94,12 @@ const initializeCodeCopy = () => {
 }
 
 const initializeHeaderRefs = () => {
-	const headers = document.querySelectorAll(".docs-content h2")
-	headers.forEach((header) => {
+	document.querySelectorAll(".docs-content h2").forEach((header) => {
+		if (header.querySelector(".header-link")) return // idempotent
 		const link = document.createElement("a")
 		link.classList.add("header-link")
-		link.innerHTML = "<span class=\"mdi mdi-link-variant\" />"
+		link.setAttribute("aria-label", `Link to ${header.textContent}`)
+		link.innerHTML = "<span class=\"mdi mdi-link-variant\" aria-hidden=\"true\" />"
 		link.href = `/vue3-ytframe/#/docs/ref=${getTitleID(header.innerText)}`
 		header.appendChild(link)
 	})

--- a/src/views/DocsPage.vue
+++ b/src/views/DocsPage.vue
@@ -156,22 +156,33 @@ const onStateChange = (event) => {
 
 .docs-content {
 	overflow: auto;
-	padding: 1rem 20px v-bind(footerHeight) 220px;
+	padding: 1.5rem 1.5rem v-bind(footerHeight) 244px;
 	height: calc(100vh - v-bind(appBarHeight) - v-bind(footerHeight));
+	scroll-behavior: smooth;
 
 	@media only screen and (width <= 600px) {
-		padding-left: 1rem;
+		padding-left: 1.25rem;
 	}
 
 	section {
-		margin-bottom: 3rem;
+		margin-bottom: 3.5rem;
 	}
 
 	h2 {
-		margin-block: 1.5rem 1rem;
+		display: flex;
+		align-items: center;
+		gap: .4rem;
+		font-size: 1.7rem;
+		font-weight: 800;
+		letter-spacing: -.5px;
+		margin-block: 1.5rem 1.25rem;
+		padding-bottom: .5rem;
+		border-bottom: 1px solid var(--border);
 	}
 
 	h3 {
+		font-size: 1.25rem;
+		font-weight: 700;
 		margin-bottom: 1rem;
 	}
 
@@ -181,99 +192,148 @@ const onStateChange = (event) => {
 
 	p, li {
 		margin-bottom: .8rem;
+		line-height: 1.7;
 	}
 
 	.content-list {
-		padding-left: 1rem;
+		padding-left: 1.25rem;
+	}
+
+	/* ---- Code ---- */
+	code {
+		font-family: monospace;
+		font-size: .85em;
+		background: var(--code-bg);
+		border: 1px solid var(--border);
+		border-radius: 6px;
+		padding: .12rem .4rem;
 	}
 
 	pre {
-		margin-bottom: 1rem;
 		position: relative;
-		border-radius: 4px;
-		background: #e6e6e6 !important;
+		margin-bottom: 1.25rem;
+		border: 1px solid var(--border);
+		border-radius: 10px;
+		background: var(--code-bg);
+		overflow: auto;
+		max-height: 60vh;
+
+		code {
+			display: block;
+			border: 0;
+			background: transparent;
+			padding: 1rem 1.1rem;
+			font-size: .85rem;
+			line-height: 1.6;
+		}
 	}
 
-	code {
-		outline: 1px solid grey;
-		border-radius: 6px;
-		padding: .2rem .4rem;
-	}
-
-	code, pre>code {
-		border-radius: 4px !important;
-		background: #e6e6e6 !important;
-		max-height: 50vh;
-	}
-
-	pre>button {
+	.copy-button {
 		position: absolute;
-		right: 1%;
-		top: 8px;
-		font-size: 12px;
-		padding: .2rem;
+		top: .5rem;
+		right: .5rem;
+		display: inline-flex;
+		align-items: center;
+		font-size: .95rem;
+		padding: .25rem .4rem;
+		color: var(--muted);
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: 7px;
 		cursor: pointer;
+		opacity: 0;
+		transition: opacity .15s, color .15s, border-color .15s;
+
+		&:hover {
+			color: var(--vue-color);
+			border-color: var(--vue-color);
+		}
 	}
 
+	.copy-button:focus-visible,
+	pre:hover .copy-button {
+		opacity: 1;
+	}
+
+	/* ---- Heading anchors ---- */
 	.header-link {
-		font-size: 1.2rem;
-		padding-inline: .4rem;
-		cursor: pointer;
+		display: inline-flex;
+		font-size: 1.1rem;
+		color: var(--muted);
+		text-decoration: none;
+		opacity: 0;
+		transition: opacity .15s, color .15s;
+
+		&:hover {
+			color: var(--vue-color);
+		}
 	}
 
-	table {
-		border: 1px solid grey;
+	h2:hover .header-link {
+		opacity: 1;
+	}
 
-		th {
+	/* ---- Tables ---- */
+	table {
+		width: 100%;
+		border-collapse: separate;
+		border-spacing: 0;
+		border: 1px solid var(--border);
+		border-radius: 10px;
+		overflow: hidden;
+		margin-bottom: 1.25rem;
+
+		th, td {
+			padding: .65rem .8rem;
+			border-bottom: 1px solid var(--border);
 			text-align: left;
+			vertical-align: top;
 		}
 
-		td, th {
-			padding: .5rem;
-			border: 1px solid grey;
+		th {
+			background: var(--surface-2);
+			font-weight: 700;
+		}
+
+		tbody tr:last-child td {
+			border-bottom: 0;
+		}
+
+		tbody tr:hover {
+			background: var(--surface-2);
 		}
 	}
 
 	iframe {
 		margin-block: .5rem;
-		border-radius: 8px;
-	}
-}
-
-body.theme--dark {
-	pre, code, pre>code {
-		background: #303030 !important;
-		color: rgb(170 170 170);
+		border-radius: 10px;
 	}
 
-	pre>button {
-		color: #fff;
-		background: #1a1a1a;
-	}
-}
+	/* ---- Note callout ---- */
+	blockquote.doc-note {
+		margin: 1.25rem 0 1.5rem;
+		padding: 1rem 1.25rem;
+		border: 1px solid rgb(196 48 43 / 30%);
+		border-left: 4px solid #c4302b;
+		border-radius: 10px;
+		background: rgb(196 48 43 / 8%);
 
-.docs-content blockquote.doc-note {
-	margin: 1.25rem 0 1.5rem;
-	padding: 1rem 1.25rem;
-	border-left: 4px solid #c4302b;
-	border-radius: 4px;
-	background: rgb(196 48 43 / 8%);
+		p {
+			line-height: 1.8;
 
-	p {
-		line-height: 1.8;
+			code {
+				padding: .1rem .3rem;
+			}
 
-		code {
-			padding: .1rem;
+			&:last-child {
+				margin-bottom: 0;
+			}
 		}
 
-		&:last-child {
-			margin-bottom: 0;
+		.mdi {
+			vertical-align: middle;
+			margin-right: .25rem;
 		}
-	}
-
-	.mdi {
-		vertical-align: middle;
-		margin-right: 0.25rem;
 	}
 }
 

--- a/src/views/PlaygroundPage.vue
+++ b/src/views/PlaygroundPage.vue
@@ -24,11 +24,11 @@
 					<input id="video-url" type="url" v-model="videoUrl">
 				</div>
 			</div>
-			<div style="display: flex; flex-direction: column; flex-grow: 1;">
+			<div class="field-col">
 				<div class="title">Width ({{ width }}/800)</div>
 				<input type="range" min="100" max="800" v-model="width" class="slider" id="player-width">
 			</div>
-			<div style="display: flex; flex-direction: column; flex-grow: 1;">
+			<div class="field-col">
 				<div class="title">Height ({{ height }}/600)</div>
 				<input type="range" min="100" max="600" v-model="height" class="slider" id="player-height">
 			</div>
@@ -37,7 +37,7 @@
 				<div>
 					<label for="autoplay">
 						Autoplay
-						(<a :href="ppRef('autoplay')" target="_blank">Ref</a>)
+						(<a :href="ppRef('autoplay')" target="_blank" rel="noopener noreferrer">Ref</a>)
 					</label>
 					<input id="autoplay" type="checkbox" v-model="playerVars.autoplay">
 				</div>
@@ -45,7 +45,7 @@
 				<div>
 					<label for="cc-lang-pref">
 						CC Lang Pref
-						(<a :href="ppRef('cc_lang_pref')" target="_blank">Ref</a>)
+						(<a :href="ppRef('cc_lang_pref')" target="_blank" rel="noopener noreferrer">Ref</a>)
 					</label>
 					<input type="text" id="cc-lang-pref" v-model="playerVars.cc_lang_pref">
 				</div>
@@ -53,7 +53,7 @@
 				<div>
 					<label for="cc-load-policy">
 						CC Load Policy
-						(<a :href="ppRef('cc_load_policy')" target="_blank">Ref</a>)
+						(<a :href="ppRef('cc_load_policy')" target="_blank" rel="noopener noreferrer">Ref</a>)
 					</label>
 					<input type="checkbox" id="cc-load-policy" v-model="playerVars.cc_load_policy">
 				</div>
@@ -61,7 +61,7 @@
 				<div>
 					<label for="color">
 						Color
-						(<a :href="ppRef('color')" target="_blank">Ref</a>)
+						(<a :href="ppRef('color')" target="_blank" rel="noopener noreferrer">Ref</a>)
 					</label>
 					<input type="text" id="color" v-model="playerVars.color">
 				</div>
@@ -69,7 +69,7 @@
 				<div>
 					<label for="controls">
 						Controls
-						(<a :href="ppRef('controls')" target="_blank">Ref</a>)
+						(<a :href="ppRef('controls')" target="_blank" rel="noopener noreferrer">Ref</a>)
 					</label>
 					<input type="checkbox" id="controls" v-model="playerVars.controls">
 				</div>
@@ -77,7 +77,7 @@
 				<div>
 					<label for="disable-kb">
 						Disable KB
-						(<a :href="ppRef('disablekb')" target="_blank">Ref</a>)
+						(<a :href="ppRef('disablekb')" target="_blank" rel="noopener noreferrer">Ref</a>)
 					</label>
 					<input type="checkbox" id="disable-kb" v-model="playerVars.disablekb">
 				</div>
@@ -85,7 +85,7 @@
 				<div>
 					<label for="enable-js-api">
 						Enable JS API
-						(<a :href="ppRef('enablejsapi')" target="_blank">Ref</a>)
+						(<a :href="ppRef('enablejsapi')" target="_blank" rel="noopener noreferrer">Ref</a>)
 					</label>
 					<input type="checkbox" id="enable-js-api" v-model="playerVars.enablejsapi">
 				</div>
@@ -93,7 +93,7 @@
 				<div>
 					<label for="start">
 						Start (seconds)
-						(<a :href="ppRef('start')" target="_blank">Ref</a>)
+						(<a :href="ppRef('start')" target="_blank" rel="noopener noreferrer">Ref</a>)
 					</label>
 					<input type="number" id="start" v-model="playerVars.start">
 				</div>
@@ -101,7 +101,7 @@
 				<div>
 					<label for="end">
 						End (seconds)
-						(<a :href="ppRef('end')" target="_blank">Ref</a>)
+						(<a :href="ppRef('end')" target="_blank" rel="noopener noreferrer">Ref</a>)
 					</label>
 					<input type="number" id="end" v-model="playerVars.end">
 				</div>
@@ -109,7 +109,7 @@
 				<div>
 					<label for="fs">
 						FS
-						(<a :href="ppRef('fs')" target="_blank">Ref</a>)
+						(<a :href="ppRef('fs')" target="_blank" rel="noopener noreferrer">Ref</a>)
 					</label>
 					<input type="checkbox" id="fs" v-model="playerVars.fs">
 				</div>
@@ -117,7 +117,7 @@
 				<div>
 					<label for="hl">
 						HL
-						(<a :href="ppRef('hl')" target="_blank">Ref</a>)
+						(<a :href="ppRef('hl')" target="_blank" rel="noopener noreferrer">Ref</a>)
 					</label>
 					<input type="text" id="hl" v-model="playerVars.hl">
 				</div>
@@ -125,7 +125,7 @@
 				<div>
 					<label for="iv-load-policy">
 						IV Load Policy
-						(<a :href="ppRef('iv_load_policy')" target="_blank">Ref</a>)
+						(<a :href="ppRef('iv_load_policy')" target="_blank" rel="noopener noreferrer">Ref</a>)
 					</label>
 					<input type="checkbox" id="iv-load-policy" v-model="playerVars.iv_load_policy">
 				</div>
@@ -133,7 +133,7 @@
 				<div>
 					<label for="list-type">
 						List Type
-						(<a :href="ppRef('listType')" target="_blank">Ref</a>)
+						(<a :href="ppRef('listType')" target="_blank" rel="noopener noreferrer">Ref</a>)
 					</label>
 					<input type="text" id="list-type" v-model="playerVars.listType">
 				</div>
@@ -141,7 +141,7 @@
 				<div>
 					<label for="loop">
 						Loop
-						(<a :href="ppRef('loop')" target="_blank">Ref</a>)
+						(<a :href="ppRef('loop')" target="_blank" rel="noopener noreferrer">Ref</a>)
 					</label>
 					<input type="checkbox" id="loop" v-model="playerVars.loop">
 				</div>
@@ -149,7 +149,7 @@
 				<div>
 					<label for="modest-branding">
 						Modest Branding
-						(<a :href="ppRef('modestbranding')" target="_blank">Ref</a>)
+						(<a :href="ppRef('modestbranding')" target="_blank" rel="noopener noreferrer">Ref</a>)
 					</label>
 					<input type="checkbox" id="modest-branding" v-model="playerVars.modestbranding">
 				</div>
@@ -157,7 +157,7 @@
 				<div>
 					<label for="playsinline">
 						Plays Inline
-						(<a :href="ppRef('playsinline')" target="_blank">Ref</a>)
+						(<a :href="ppRef('playsinline')" target="_blank" rel="noopener noreferrer">Ref</a>)
 					</label>
 					<input type="checkbox" id="playsinline" v-model="playerVars.playsinline">
 				</div>
@@ -165,7 +165,7 @@
 				<div>
 					<label for="rel">
 						Rel
-						(<a :href="ppRef('rel')" target="_blank">Ref</a>)
+						(<a :href="ppRef('rel')" target="_blank" rel="noopener noreferrer">Ref</a>)
 					</label>
 					<input type="checkbox" id="rel" v-model="playerVars.rel">
 				</div>
@@ -306,6 +306,12 @@ const destroyPlayer = () => {
 		li {
 			margin-bottom: .5rem;
 		}
+	}
+
+	.field-col {
+		display: flex;
+		flex-direction: column;
+		flex-grow: 1;
 	}
 
 	.player-parameters {

--- a/src/views/PlaygroundPage.vue
+++ b/src/views/PlaygroundPage.vue
@@ -1,176 +1,97 @@
 <template>
 	<div class="playground">
-		<h2>Playground</h2>
-		<div class="player">
-			<VueYtframe ref="yt" :video-id="videoId" :video-url="videoUrl" :height="height"
-				:width="width" :player-vars="playerParameters" />
-			<div v-if="!videoId && !videoUrl" class="no-value">
-				Input YouTube video ID or URL to initiate the player.
-			</div>
-		</div>
-		<div class="actions" v-if="yt && yt.player">
-			<button @click="destroyPlayer()">Destroy Player</button>
-		</div>
-		<div class="props">
-			<div class="video-id">
-				<div class="title">Video ID</div>
-				<div class="text-input">
-					<input id="video-id" type="text" v-model="videoId">
-				</div>
-			</div>
-			<div class="video-url">
-				<div class="title">Video URL</div>
-				<div class="text-input">
-					<input id="video-url" type="url" v-model="videoUrl">
+		<header class="playground__header">
+			<h2 class="playground__title">Playground</h2>
+			<p class="playground__subtitle">
+				Drop in a video, resize the frame, and toggle player parameters to see them live.
+			</p>
+		</header>
+
+		<section class="stage">
+			<div class="stage__frame" :class="{'stage__frame--empty': !videoId && !videoUrl}">
+				<VueYtframe
+					ref="yt"
+					:video-id="videoId"
+					:video-url="videoUrl"
+					:height="height"
+					:width="width"
+					:player-vars="playerParameters"
+				/>
+				<div v-if="!videoId && !videoUrl" class="stage__empty">
+					<span class="mdi mdi-youtube" aria-hidden="true" />
+					<p>Enter a YouTube video ID or URL below to load the player.</p>
 				</div>
 			</div>
-			<div class="field-col">
-				<div class="title">Width ({{ width }}/800)</div>
-				<input type="range" min="100" max="800" v-model="width" class="slider" id="player-width">
+			<div v-if="yt && yt.player" class="stage__actions">
+				<button type="button" class="btn btn--danger" @click="destroyPlayer()">
+					<span class="mdi mdi-close-circle-outline" aria-hidden="true" />
+					Destroy player
+				</button>
 			</div>
-			<div class="field-col">
-				<div class="title">Height ({{ height }}/600)</div>
-				<input type="range" min="100" max="600" v-model="height" class="slider" id="player-height">
-			</div>
-			<div class="player-parameters">
-				<div class="title">Player Parameters</div>
-				<div>
-					<label for="autoplay">
-						Autoplay
-						(<a :href="ppRef('autoplay')" target="_blank" rel="noopener noreferrer">Ref</a>)
-					</label>
-					<input id="autoplay" type="checkbox" v-model="playerVars.autoplay">
-				</div>
+		</section>
 
-				<div>
-					<label for="cc-lang-pref">
-						CC Lang Pref
-						(<a :href="ppRef('cc_lang_pref')" target="_blank" rel="noopener noreferrer">Ref</a>)
-					</label>
-					<input type="text" id="cc-lang-pref" v-model="playerVars.cc_lang_pref">
+		<section class="panel">
+			<h3 class="panel__title">Video source</h3>
+			<div class="grid">
+				<div class="field">
+					<label class="field__label" for="video-id">Video ID</label>
+					<input id="video-id" class="field__input" type="text" placeholder="e.g. kGb9ftWR3l8" v-model="videoId">
 				</div>
-
-				<div>
-					<label for="cc-load-policy">
-						CC Load Policy
-						(<a :href="ppRef('cc_load_policy')" target="_blank" rel="noopener noreferrer">Ref</a>)
-					</label>
-					<input type="checkbox" id="cc-load-policy" v-model="playerVars.cc_load_policy">
+				<div class="field">
+					<label class="field__label" for="video-url">Video URL</label>
+					<input id="video-url" class="field__input" type="url" placeholder="https://youtu.be/…" v-model="videoUrl">
 				</div>
-
-				<div>
-					<label for="color">
-						Color
-						(<a :href="ppRef('color')" target="_blank" rel="noopener noreferrer">Ref</a>)
+				<div class="field">
+					<label class="field__label" for="player-width">
+						Width <span class="field__value">{{ width }} / 800</span>
 					</label>
-					<input type="text" id="color" v-model="playerVars.color">
+					<input id="player-width" class="slider" type="range" min="100" max="800" v-model="width">
 				</div>
-
-				<div>
-					<label for="controls">
-						Controls
-						(<a :href="ppRef('controls')" target="_blank" rel="noopener noreferrer">Ref</a>)
+				<div class="field">
+					<label class="field__label" for="player-height">
+						Height <span class="field__value">{{ height }} / 600</span>
 					</label>
-					<input type="checkbox" id="controls" v-model="playerVars.controls">
-				</div>
-
-				<div>
-					<label for="disable-kb">
-						Disable KB
-						(<a :href="ppRef('disablekb')" target="_blank" rel="noopener noreferrer">Ref</a>)
-					</label>
-					<input type="checkbox" id="disable-kb" v-model="playerVars.disablekb">
-				</div>
-
-				<div>
-					<label for="enable-js-api">
-						Enable JS API
-						(<a :href="ppRef('enablejsapi')" target="_blank" rel="noopener noreferrer">Ref</a>)
-					</label>
-					<input type="checkbox" id="enable-js-api" v-model="playerVars.enablejsapi">
-				</div>
-
-				<div>
-					<label for="start">
-						Start (seconds)
-						(<a :href="ppRef('start')" target="_blank" rel="noopener noreferrer">Ref</a>)
-					</label>
-					<input type="number" id="start" v-model="playerVars.start">
-				</div>
-
-				<div>
-					<label for="end">
-						End (seconds)
-						(<a :href="ppRef('end')" target="_blank" rel="noopener noreferrer">Ref</a>)
-					</label>
-					<input type="number" id="end" v-model="playerVars.end">
-				</div>
-
-				<div>
-					<label for="fs">
-						FS
-						(<a :href="ppRef('fs')" target="_blank" rel="noopener noreferrer">Ref</a>)
-					</label>
-					<input type="checkbox" id="fs" v-model="playerVars.fs">
-				</div>
-
-				<div>
-					<label for="hl">
-						HL
-						(<a :href="ppRef('hl')" target="_blank" rel="noopener noreferrer">Ref</a>)
-					</label>
-					<input type="text" id="hl" v-model="playerVars.hl">
-				</div>
-
-				<div>
-					<label for="iv-load-policy">
-						IV Load Policy
-						(<a :href="ppRef('iv_load_policy')" target="_blank" rel="noopener noreferrer">Ref</a>)
-					</label>
-					<input type="checkbox" id="iv-load-policy" v-model="playerVars.iv_load_policy">
-				</div>
-
-				<div>
-					<label for="list-type">
-						List Type
-						(<a :href="ppRef('listType')" target="_blank" rel="noopener noreferrer">Ref</a>)
-					</label>
-					<input type="text" id="list-type" v-model="playerVars.listType">
-				</div>
-
-				<div>
-					<label for="loop">
-						Loop
-						(<a :href="ppRef('loop')" target="_blank" rel="noopener noreferrer">Ref</a>)
-					</label>
-					<input type="checkbox" id="loop" v-model="playerVars.loop">
-				</div>
-
-				<div>
-					<label for="modest-branding">
-						Modest Branding
-						(<a :href="ppRef('modestbranding')" target="_blank" rel="noopener noreferrer">Ref</a>)
-					</label>
-					<input type="checkbox" id="modest-branding" v-model="playerVars.modestbranding">
-				</div>
-
-				<div>
-					<label for="playsinline">
-						Plays Inline
-						(<a :href="ppRef('playsinline')" target="_blank" rel="noopener noreferrer">Ref</a>)
-					</label>
-					<input type="checkbox" id="playsinline" v-model="playerVars.playsinline">
-				</div>
-
-				<div>
-					<label for="rel">
-						Rel
-						(<a :href="ppRef('rel')" target="_blank" rel="noopener noreferrer">Ref</a>)
-					</label>
-					<input type="checkbox" id="rel" v-model="playerVars.rel">
+					<input id="player-height" class="slider" type="range" min="100" max="600" v-model="height">
 				</div>
 			</div>
-		</div>
+		</section>
+
+		<section class="panel">
+			<h3 class="panel__title">Player parameters</h3>
+			<div class="params-grid">
+				<div
+					v-for="field in paramFields"
+					:key="field.key"
+					class="control"
+					:class="{'control--toggle': field.type === 'checkbox'}"
+				>
+					<label class="control__label" :for="field.key">
+						{{ field.label }}
+						<a
+							class="control__ref"
+							:href="ppRef(field.refKey)"
+							target="_blank"
+							rel="noopener noreferrer"
+							:title="`${field.label} reference`"
+						>
+							<span class="mdi mdi-open-in-new" aria-hidden="true" />
+						</a>
+					</label>
+
+					<label v-if="field.type === 'checkbox'" class="toggle">
+						<input :id="field.key" type="checkbox" v-model="playerVars[field.key]">
+						<span class="toggle__slider" />
+					</label>
+					<input
+						v-else
+						:id="field.key"
+						class="control__input"
+						:type="field.type"
+						v-model="playerVars[field.key]"
+					>
+				</div>
+			</div>
+		</section>
 	</div>
 </template>
 <script setup>
@@ -189,6 +110,28 @@ const ppRef = (key) => {
 	return playerParameterRef.replace("%s", key)
 }
 
+// Drives the parameter controls grid. `key` binds to playerVars; `refKey` is
+// the anchor on the YouTube player-parameters reference page.
+const paramFields = [
+	{ key: "autoplay", refKey: "autoplay", label: "Autoplay", type: "checkbox" },
+	{ key: "cc_lang_pref", refKey: "cc_lang_pref", label: "CC Lang Pref", type: "text" },
+	{ key: "cc_load_policy", refKey: "cc_load_policy", label: "CC Load Policy", type: "checkbox" },
+	{ key: "color", refKey: "color", label: "Color", type: "text" },
+	{ key: "controls", refKey: "controls", label: "Controls", type: "checkbox" },
+	{ key: "disablekb", refKey: "disablekb", label: "Disable KB", type: "checkbox" },
+	{ key: "enablejsapi", refKey: "enablejsapi", label: "Enable JS API", type: "checkbox" },
+	{ key: "start", refKey: "start", label: "Start (seconds)", type: "number" },
+	{ key: "end", refKey: "end", label: "End (seconds)", type: "number" },
+	{ key: "fs", refKey: "fs", label: "Fullscreen", type: "checkbox" },
+	{ key: "hl", refKey: "hl", label: "Interface Language", type: "text" },
+	{ key: "iv_load_policy", refKey: "iv_load_policy", label: "IV Load Policy", type: "checkbox" },
+	{ key: "listType", refKey: "listType", label: "List Type", type: "text" },
+	{ key: "loop", refKey: "loop", label: "Loop", type: "checkbox" },
+	{ key: "modestbranding", refKey: "modestbranding", label: "Modest Branding", type: "checkbox" },
+	{ key: "playsinline", refKey: "playsinline", label: "Plays Inline", type: "checkbox" },
+	{ key: "rel", refKey: "rel", label: "Related Videos", type: "checkbox" },
+]
+
 const playerVars = ref({
 	autoplay: null,
 	cc_lang_pref: null,
@@ -205,7 +148,6 @@ const playerVars = ref({
 	loop: null,
 	modestbranding: null,
 	origin: window.location.origin,
-	// playlist: playlist.value,
 	playsinline: null,
 	rel: null,
 	start: null
@@ -231,115 +173,319 @@ const destroyPlayer = () => {
 		yt.value.destroy()
 		videoId.value = null
 		videoUrl.value = null
-
 	}
 }
 </script>
 <style lang="scss">
 .playground {
-	font-size: .875rem;
-	overflow: auto;
-	padding: 1rem 1rem 20rem;
-	max-width: 1000px;
+	--pg-surface: #fff;
+	--pg-surface-2: #f6f7f9;
+	--pg-border: #e4e6ea;
+	--pg-muted: #6b7280;
+	--pg-stage: #f1f3f5;
+	--pg-toggle-track: #cdd2d8;
+
+	max-width: 1080px;
 	margin: 0 auto;
+	padding: 1.5rem 1rem 8rem;
+	font-size: .9rem;
 
-	.player {
-		margin-block: 1rem;
-		border-radius: 4px;
-		border: 1px solid grey;
-		width: fit-content;
-		max-width: 800px;
-		max-height: 600px;
+	&__header {
+		margin-bottom: 1.5rem;
 	}
 
-	.actions, .props {
-		max-width: 600px;
+	&__title {
+		font-size: clamp(1.5rem, 3vw, 2.25rem);
+		font-weight: 800;
+		letter-spacing: -.5px;
 	}
 
-	.actions {
-		display: flex;
-		flex-wrap: wrap;
-		align-items: center;
+	&__subtitle {
+		margin-top: .35rem;
+		color: var(--pg-muted);
+		font-size: 1rem;
+	}
+
+	.panel {
+		background: var(--pg-surface);
+		border: 1px solid var(--pg-border);
+		border-radius: 14px;
+		padding: 1.25rem;
+		margin-bottom: 1.25rem;
+		box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+	}
+
+	.panel__title {
+		font-size: 1rem;
+		font-weight: 700;
 		margin-bottom: 1rem;
+		display: flex;
+		align-items: center;
+		gap: .5rem;
+
+		&::before {
+			content: "";
+			width: 4px;
+			height: 1.1em;
+			border-radius: 2px;
+			background: var(--vue-color);
+		}
 	}
 
-	.title {
-		font-size: 1rem;
-		font-weight: 500;
-		margin-bottom: .5rem;
+	/* ---- Stage / preview ---- */
+	.stage {
+		margin-bottom: 1.25rem;
+
+		&__frame {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			min-height: 240px;
+			padding: 1.25rem;
+			background: var(--pg-stage);
+			border: 1px solid var(--pg-border);
+			border-radius: 16px;
+			overflow: hidden;
+
+			iframe {
+				border-radius: 10px;
+				box-shadow: 0 10px 30px rgb(0 0 0 / 18%);
+				max-width: 100%;
+			}
+		}
+
+		&__frame--empty {
+			border-style: dashed;
+		}
+
+		&__empty {
+			text-align: center;
+			color: var(--pg-muted);
+
+			.mdi {
+				font-size: 3.5rem;
+				color: #c4302b;
+				opacity: .8;
+			}
+
+			p {
+				margin-top: .5rem;
+			}
+		}
+
+		&__actions {
+			display: flex;
+			justify-content: center;
+			margin-top: 1rem;
+		}
 	}
 
-	.text-input {
-		position: relative;
-
-		// width: fit-content;
+	/* ---- Buttons ---- */
+	.btn {
+		display: inline-flex;
+		align-items: center;
+		gap: .4rem;
+		font: inherit;
+		font-weight: 600;
+		padding: .5rem .9rem;
+		border-radius: 10px;
+		border: 1px solid transparent;
+		cursor: pointer;
+		transition: background .15s, border-color .15s;
 	}
 
-	input {
-		font-size: .875rem;
-		border-radius: 4px;
-		padding: .3rem 1.5rem .3rem .3rem;
-		margin-bottom: .5rem;
+	.btn--danger {
+		color: #c4302b;
+		background: rgb(196 48 43 / 8%);
+		border-color: rgb(196 48 43 / 25%);
+
+		&:hover {
+			background: rgb(196 48 43 / 15%);
+		}
 	}
 
-	input[type="text"], input[type="url"] {
+	/* ---- Generic fields ---- */
+	.grid {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 1rem 1.25rem;
+
+		@media (width <= 600px) {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: .4rem;
+
+		&__label {
+			font-weight: 600;
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			gap: .5rem;
+		}
+
+		&__value {
+			font-weight: 500;
+			font-size: .8rem;
+			color: var(--vue-color);
+			background: rgb(66 184 131 / 12%);
+			padding: .1rem .5rem;
+			border-radius: 999px;
+		}
+
+		&__input {
+			width: 100%;
+		}
+	}
+
+	input[type="text"],
+	input[type="url"],
+	input[type="number"] {
 		width: 100%;
+		font: inherit;
+		padding: .5rem .65rem;
+		border-radius: 9px;
+		border: 1px solid var(--pg-border);
+		background: var(--pg-surface);
+		color: inherit;
+		transition: border-color .15s, box-shadow .15s;
+
+		&::placeholder {
+			color: var(--pg-muted);
+			opacity: .7;
+		}
+
+		&:focus {
+			outline: none;
+			border-color: var(--vue-color);
+			box-shadow: 0 0 0 3px rgb(66 184 131 / 18%);
+		}
 	}
 
-	.mdi-close {
-		position: absolute;
-		color: green;
-		font-size: 1rem;
-		top: 20%;
-		right: 3%;
+	.slider {
+		width: 100%;
+		accent-color: var(--vue-color);
 		cursor: pointer;
 	}
 
-	.no-value {
-		padding: 1rem;
+	/* ---- Parameter controls ---- */
+	.params-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+		gap: .75rem;
 	}
 
-	ul {
-		margin-bottom: 1rem;
-		padding-left: 1rem;
-
-		li {
-			margin-bottom: .5rem;
-		}
-	}
-
-	.field-col {
+	.control {
 		display: flex;
 		flex-direction: column;
-		flex-grow: 1;
+		gap: .5rem;
+		padding: .75rem .85rem;
+		border: 1px solid var(--pg-border);
+		border-radius: 11px;
+		background: var(--pg-surface-2);
+		transition: border-color .15s;
+
+		&:hover {
+			border-color: var(--vue-color);
+		}
+
+		&--toggle {
+			flex-direction: row;
+			align-items: center;
+			justify-content: space-between;
+		}
+
+		&__label {
+			font-weight: 600;
+			display: inline-flex;
+			align-items: center;
+			gap: .35rem;
+		}
+
+		&__ref {
+			color: var(--pg-muted);
+			text-decoration: none;
+			display: inline-flex;
+			font-size: .85rem;
+
+			&:hover {
+				color: var(--vue-color);
+			}
+		}
 	}
 
-	.player-parameters {
-		&>div {
-			display: flex;
-			align-items: center;
+	/* ---- Toggle switch ---- */
+	.toggle {
+		position: relative;
+		display: inline-block;
+		width: 42px;
+		height: 24px;
+		flex-shrink: 0;
+
+		input {
+			position: absolute;
+			inset: 0;
+			width: 100%;
+			height: 100%;
+			margin: 0;
+			opacity: 0;
+			cursor: pointer;
 		}
 
-		label {
-			width: 150px;
-			min-width: 150px;
+		&__slider {
+			position: absolute;
+			inset: 0;
+			background: var(--pg-toggle-track);
+			border-radius: 999px;
+			transition: background .2s;
+
+			&::before {
+				content: "";
+				position: absolute;
+				width: 18px;
+				height: 18px;
+				top: 3px;
+				left: 3px;
+				background: #fff;
+				border-radius: 50%;
+				box-shadow: 0 1px 2px rgb(0 0 0 / 25%);
+				transition: transform .2s;
+			}
 		}
 
-		input[type="checkbox"] {
-			width: 18px;
-			height: 18px;
+		input:checked + .toggle__slider {
+			background: var(--vue-color);
+
+			&::before {
+				transform: translateX(18px);
+			}
+		}
+
+		input:focus-visible + .toggle__slider {
+			outline: 2px solid var(--vue-color);
+			outline-offset: 2px;
 		}
 	}
 
 	a {
 		color: darkgreen;
-		text-decoration: underline;
 	}
 }
 
-body.theme--dark {
+body.theme--dark .playground {
+	--pg-surface: #242424;
+	--pg-surface-2: #1e1e1e;
+	--pg-border: #383838;
+	--pg-muted: #9ca3af;
+	--pg-stage: #161616;
+	--pg-toggle-track: #4a4a4a;
+
 	a {
-		color: var(--vue-color)
+		color: var(--vue-color);
 	}
 }
 </style>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"lib": ["ESNext", "DOM", "DOM.Iterable"],
+		"types": ["youtube", "vite/client", "node"],
+		"allowJs": true,
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"verbatimModuleSyntax": true,
+		"jsx": "preserve",
+		"noEmit": true,
+		"declaration": true,
+		"emitDeclarationOnly": true
+	},
+	"include": ["lib/**/*.ts", "lib/**/*.vue", "lib/**/*.d.ts"],
+	"exclude": ["node_modules", "dist", "docs"]
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,24 +1,50 @@
 import {dirname, resolve} from "node:path"
 import {fileURLToPath} from "node:url"
-import {defineConfig} from "vite"
+import {defineConfig} from "vitest/config"
 import vue from "@vitejs/plugin-vue"
+import dts from "vite-plugin-dts"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
+
+const test = {
+	environment: "happy-dom",
+	include: ["lib/**/*.{test,spec}.{js,ts}"],
+	coverage: {
+		provider: "v8",
+		include: ["lib/**/*.{js,ts,vue}"],
+		exclude: ["lib/**/*.{test,spec}.*", "lib/**/*.d.ts"],
+		thresholds: {
+			statements: 80,
+			branches: 80,
+			functions: 80,
+			lines: 80,
+		},
+	},
+}
 
 // https://vite.dev/config/
 export default defineConfig(({command, mode}) => {
 	if (command === "serve") {
 		return {
 			plugins: [vue()],
+			test,
 		}
 	}
 
 	if (mode === "lib") {
 		return {
-			plugins: [vue()],
+			plugins: [
+				vue(),
+				dts({
+					tsconfigPath: resolve(__dirname, "tsconfig.json"),
+					include: ["lib/**/*.ts", "lib/**/*.vue"],
+					exclude: ["lib/**/*.{test,spec}.*"],
+					entryRoot: "lib",
+				}),
+			],
 			build: {
 				lib: {
-					entry: resolve(__dirname, "lib/index.js"),
+					entry: resolve(__dirname, "lib/index.ts"),
 					name: "VueYtframe",
 					fileName: (format) =>
 						format === "umd" ? "ytframe.umd.cjs" : `ytframe.${format}.js`,
@@ -26,6 +52,7 @@ export default defineConfig(({command, mode}) => {
 				rollupOptions: {
 					external: ["vue"],
 					output: {
+						exports: "named",
 						globals: {
 							vue: "Vue",
 						},


### PR DESCRIPTION
## Summary

Quality-focused **v1.0.0** release: the library is rewritten in TypeScript, ships first-party types, adds a Vitest suite, and fixes several long-standing runtime issues. The default plugin API (`import VueYtframe from "vue3-ytframe"` + `app.use`) and existing props/events/methods stay the same for typical ESM/bundler apps.

**Added**
- TypeScript source (`<script setup lang="ts">`) with shipped `dist/lib/index.d.ts`
- `VueYtframeInstance` for template refs; named `VueYtframe` export for local registration
- `getVideoIdFromYoutubeURL` exported from the package
- Broader YouTube URL parsing (`shorts/`, `live/`, `youtube-nocookie.com`, `/v/`, `http`, `v=` not first in query)
- Vitest coverage (URL utils, debounce, component lifecycle/methods, docs/API drift guard)
- `lib/constants.ts`, `lib/utils.ts`, `lib/types.ts`; dev-only `warn()` diagnostics

**Fixed**
- Debounce actually coalesces (300ms `videoId`, 500ms `videoUrl`) instead of recreating handlers each change
- Player destroyed on unmount (no iframe/API leak)
- Bounded YouTube Iframe API load (timeout vs infinite poll)
- Consistent autoplay handling across `videoId` / `videoUrl` paths
- `endSeconds` omitted when unset (no longer forced to `0`)
- Clear errors when calling player methods before ready

**Changed**
- Production builds no longer `console.warn` (dev-only)
- UMD named exports — CDN users use `VueYtframe.default` / `VueYtframe.VueYtframe`
- Demo docs/playground updated; CI runs tests; publish workflows aligned with TS build

See `CHANGELOG.md` for full migration notes (mainly UMD/CDN consumers).

## Test plan

- [x] `pnpm test` — all Vitest tests pass
- [x] `pnpm run build` — ESM + UMD + `.d.ts` emit cleanly
- [x] `pnpm run lint` — ESLint clean
- [ ] Demo app: `pnpm dev` — player loads, prop changes debounce, unmount removes iframe
- [ ] Docs page matches exported API (docs-drift test passes)
- [ ] Smoke: global plugin install and `import { VueYtframe }` local registration
- [ ] Optional: verify UMD global shape if you p builds


Ship built-in types, Vitest coverage, and debounce/unmount/API-load fixes.
Export getVideoIdFromYoutubeURL and named VueYtframe; extend YouTube URL parsing.
Update docs, demo app, and publish/CI workflows.

Signed-off-by: Kiran Parajuli <39373750+kiranparajuli589@users.noreply.github.com>
